### PR TITLE
feat: Add ReportParamFlags endpoint to fetch report parameter flags by REPID

### DIFF
--- a/Controllers/ReportParamFlagsController.cs
+++ b/Controllers/ReportParamFlagsController.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Net;
+using System.Web.Http;
+using MISReports_Api.DAL;
+using MISReports_Api.Models.Admin.Report_Parameters;
+
+namespace MISReports_Api.Controllers
+{
+    [RoutePrefix("api/report-params")]
+    public class ReportParamFlagsController : ApiController
+    {
+        private readonly ReportParamFlagsRepository _repository = new ReportParamFlagsRepository();
+
+        // GET api/report-params/{repId}
+        // e.g. GET api/report-params/COSTCENTERTRIAL
+        [HttpGet]
+        [Route("{repId}")]
+        public IHttpActionResult GetReportParamFlags(string repId)
+        {
+            if (string.IsNullOrWhiteSpace(repId))
+                return Content(HttpStatusCode.BadRequest,
+                    ApiResponse<object>.Fail("repId is required."));
+
+            try
+            {
+                var result = _repository.GetReportParamFlags(repId);
+
+                if (result == null)
+                    return Content(HttpStatusCode.NotFound,
+                        ApiResponse<object>.Fail($"No report found with repId '{repId}'."));
+
+                return Content(HttpStatusCode.OK,
+                    ApiResponse<object>.Ok(result, "Report parameter flags fetched successfully."));
+            }
+            catch (Exception ex)
+            {
+                return Content(HttpStatusCode.InternalServerError,
+                    ApiResponse<object>.Fail("Failed to fetch report parameter flags: " + ex.Message));
+            }
+        }
+    }
+}

--- a/DAL/ReportParamFlagsRepository.cs
+++ b/DAL/ReportParamFlagsRepository.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using Oracle.ManagedDataAccess.Client;
+using MISReports_Api.Models;
+
+namespace MISReports_Api.DAL
+{
+    public class ReportParamFlagsRepository
+    {
+        private readonly string _connectionString = ConfigurationManager.ConnectionStrings["OracleTest"].ConnectionString;
+
+        public ReportParamFlagsModel GetReportParamFlags(string repId)
+        {
+            const string sql = @"
+SELECT TRIM(repid)     AS repid,
+       TRIM(repname)   AS repname,
+       TRIM(paramlist) AS paramlist
+FROM   rep_reports_new
+WHERE  UPPER(TRIM(repid)) = :repId";
+
+            using (var conn = new OracleConnection(_connectionString))
+            {
+                conn.Open();
+                using (var cmd = new OracleCommand(sql, conn))
+                {
+                    cmd.BindByName = true;
+                    cmd.Parameters.Add("repId", OracleDbType.Varchar2).Value = repId?.Trim().ToUpperInvariant();
+
+                    using (var reader = cmd.ExecuteReader())
+                    {
+                        if (!reader.Read())
+                            return null;
+
+                        var fetchedRepId = reader["REPID"]?.ToString()?.Trim();
+                        var repName = reader["REPNAME"]?.ToString()?.Trim();
+                        var paramList = reader["PARAMLIST"]?.ToString()?.Trim();
+
+                        var flags = ParseParamList(paramList);
+
+                        return new ReportParamFlagsModel
+                        {
+                            RepId = fetchedRepId,
+                            RepName = repName,
+                            Params = flags
+                        };
+                    }
+                }
+            }
+        }
+
+        // Parses "REGION=0&CCT=1&YEAR=1&MONTH=1&..." into a Dictionary<string, int>
+        private static Dictionary<string, int> ParseParamList(string paramList)
+        {
+            var result = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            if (string.IsNullOrWhiteSpace(paramList))
+                return result;
+
+            foreach (var token in paramList.Split('&'))
+            {
+                var trimmed = token.Trim();
+                if (string.IsNullOrWhiteSpace(trimmed))
+                    continue;
+
+                var eqIndex = trimmed.IndexOf('=');
+                if (eqIndex <= 0)
+                    continue;
+
+                var key = trimmed.Substring(0, eqIndex).Trim().ToUpperInvariant();
+                var value = trimmed.Substring(eqIndex + 1).Trim();
+
+                if (int.TryParse(value, out var intValue))
+                    result[key] = intValue;
+            }
+
+            return result;
+        }
+    }
+}

--- a/MISReports_Api.csproj
+++ b/MISReports_Api.csproj
@@ -303,6 +303,7 @@
     <Compile Include="Controllers\JobCard\JobCardMaterialsController.cs" />
     <Compile Include="Controllers\JobSearch\JobSearchController.cs" />
     <Compile Include="Controllers\JobSearch\JobSearchMainTableController.cs" />
+    <Compile Include="Controllers\ReportParamFlagsController.cs" />
     <Compile Include="Controllers\SolarJobs\CcApplicationController.cs" />
     <Compile Include="Controllers\LedgerCard\DivisionalLedgerCardController.cs" />
     <Compile Include="Controllers\LedgerCard\LedgerCardController.cs" />
@@ -427,6 +428,7 @@
     <Compile Include="DAL\JobCard\JobCardMaterialsRepository.cs" />
     <Compile Include="DAL\JobSearch\JobSearchMainTableRepository.cs" />
     <Compile Include="DAL\JobSearch\JobSearchRepository.cs" />
+    <Compile Include="DAL\ReportParamFlagsRepository.cs" />
     <Compile Include="DAL\Shared\CalcCycleFromAreaDao.cs" />
     <Compile Include="DAL\SolarJobs\CcApplicationRepository.cs" />
     <Compile Include="DAL\LedgerCard\DivisionalLedgerCardRepository.cs" />
@@ -594,6 +596,7 @@
     <Compile Include="Models\JobSearch\JobSearchDtos.cs" />
     <Compile Include="Models\JobSearch\JobSearchMainTable.cs" />
     <Compile Include="Models\JobSearch\JobSearchModel.cs" />
+    <Compile Include="Models\ReportParamFlagsModel.cs" />
     <Compile Include="Models\Shared\CalcCycleModel.cs" />
     <Compile Include="Models\SolarJobs\CcApplicationModel.cs" />
     <Compile Include="Models\LedgerCard\DivisionalLedgerCardModel.cs" />

--- a/Models/ReportParamFlagsModel.cs
+++ b/Models/ReportParamFlagsModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace MISReports_Api.Models
+{
+    public class ReportParamFlagsModel
+    {
+        public string RepId { get; set; }
+        public string RepName { get; set; }
+        public Dictionary<string, int> Params { get; set; }
+    }
+}


### PR DESCRIPTION
## Description:
Adds a new lightweight endpoint that accepts a `REPID` string and returns the parsed parameter flags for that report from `rep_reports_new`. This is used by the frontend `GenericReportPage` to dynamically show/hide input fields (year, month, cost centre, date range, etc.) based on what each report actually needs.
## Changes:

- `Models/Admin/Report_Parameters/ReportParamFlagsModel.cs` — new model with `RepId`, `RepName`, and `Params` (`Dictionary<string, int>`)
- `DAL/Admin/Report_Parameters/ReportParamFlagsRepository.cs` — queries `rep_reports_new` by `REPID` (with `UPPER(TRIM(...))` for safe matching on the `char(100)` column), parses the `PARAMLIST` string (`REGION=0&CCT=1&YEAR=1&...`) into a dictionary
- `Controllers/Admin/Report_Parameters/ReportParamFlagsController.cs` — exposes `GET api/report-params/{repId}`, returns 400 for missing input, 404 if repId not found, 500 on error
## Endpoint:
`GET /api/report-params/{repId}`
## Example:
`GET /api/report-params/COSTCENTERTRIAL`
```
{
  "Success": true,
  "Message": "Report parameter flags fetched successfully.",
  "Data": {
    "RepId": "COSTCENTERTRIAL",
    "RepName": "Cost Center Trial Balance",
    "Params": {
      "CCT": 1,
      "YEAR": 1,
      "MONTH": 1,
      "REGION": 0,
      ...
    }
  }
}
```
## Notes:

- Oracle connection string key `OracleTest` — same as all other admin repositories
- `REPID` column is `char(100)` padded — `TRIM` applied on both sides of the comparison