### PR TITLE
Add status filtering to material master API

### DIFF
--- a/Controllers/Inventory/MaterialMasterController.cs
+++ b/Controllers/Inventory/MaterialMasterController.cs
@@ -1,47 +1,68 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
 using System.Web.Http;
 using MISReports_Api.DAL;
-using MISReports_Api.Models.Inventory;
+
 namespace MISReports_Api.Controllers
 {
     [RoutePrefix("api/materialmaster")]
     public class MaterialMasterController : ApiController
     {
         private readonly MaterialMasterDAL _dal = new MaterialMasterDAL();
-        // PATH: /api/materialmaster/report/RM-1001
+
+        // PATH:
+        // /api/materialmaster/report/RM-1001
+        // /api/materialmaster/report/RM-1001?status=2
         [HttpGet]
         [Route("report/{matCode}")]
-        public IHttpActionResult GetReport(string matCode)
+        public IHttpActionResult GetReport(string matCode, [FromUri] int? status = null)
         {
-            return ExecuteQuery(matCode);
+            return ExecuteQuery(matCode, status);
         }
-        // QUERY: /api/materialmaster/report?matCode=RM-1001
+
+        // QUERY:
+        // /api/materialmaster/report
+        // /api/materialmaster/report?matCode=RM-1001
+        // /api/materialmaster/report?status=2
+        // /api/materialmaster/report?matCode=RM-1001&status=2
         [HttpGet]
         [Route("report")]
-        public IHttpActionResult GetQuery([FromUri] string matCode = null)
+        public IHttpActionResult GetQuery([FromUri] string matCode = null, [FromUri] int? status = null)
         {
-            return ExecuteQuery(matCode);
+            return ExecuteQuery(matCode, status);
         }
-        private IHttpActionResult ExecuteQuery(string matCode)
+
+        private IHttpActionResult ExecuteQuery(string matCode, int? status)
         {
             try
             {
-                // matCode is optional: blank/null returns all material master records.
-                string matCodeTrimmed = string.IsNullOrWhiteSpace(matCode) ? null : matCode.Trim();
-                var data = _dal.GetMaterialMaster(matCodeTrimmed);
+                string matCodeTrimmed = string.IsNullOrWhiteSpace(matCode)
+                    ? null
+                    : matCode.Trim();
+
+                // Allow only 2 or 3
+                if (status.HasValue && status != 2 && status != 3)
+                {
+                    return BadRequest("Status must be 2 (Active) or 3 (Inactive).");
+                }
+
+                var data = _dal.GetMaterialMaster(matCodeTrimmed, status);
+
                 var summary = new
                 {
                     matCode = matCodeTrimmed ?? "(all)",
+                    status = status.HasValue
+                        ? (status == 2 ? "Active" : "Inactive")
+                        : "Both",
                     totalRecords = data.Count
                 };
+
                 return Ok(new
                 {
                     success = true,
-                    message = data.Any() ? "Data retrieved successfully" : "No records found",
+                    message = data.Any()
+                        ? "Data retrieved successfully"
+                        : "No records found",
                     data,
                     summary
                 });
@@ -49,7 +70,9 @@ namespace MISReports_Api.Controllers
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"Error: {ex.Message}\n{ex.StackTrace}");
-                return InternalServerError(new Exception($"Database error: {ex.Message}", ex));
+
+                return InternalServerError(
+                    new Exception($"Database error: {ex.Message}", ex));
             }
         }
     }

--- a/DAL/Inventory/MaterialMasterDAL.cs
+++ b/DAL/Inventory/MaterialMasterDAL.cs
@@ -1,59 +1,64 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Web;
 using System.Configuration;
 using System.Data;
 using Oracle.ManagedDataAccess.Client;
 using MISReports_Api.Models.Inventory;
+
 namespace MISReports_Api.DAL
 {
     public class MaterialMasterDAL
     {
         private readonly string _connectionString =
             ConfigurationManager.ConnectionStrings["HQOracle"].ConnectionString;
-        public List<MaterialMasterModel> GetMaterialMaster(string matCode)
+
+        public List<MaterialMasterModel> GetMaterialMaster(string matCode, int? status)
         {
             var result = new List<MaterialMasterModel>();
-            // NOTE: (status != 2 OR status != 3) is always true for any status value
-            // (a row can't fail both at once), so as written this does not actually
-            // restrict results to Active/Inactive only. Left matching the SQL as
-            // received from the report spec — flag with your senior; likely meant
-            // to be "status IN (2, 3)".
+
             const string query = @"
                 SELECT A.mat_cd,
                        A.mat_nm,
                        A.maj_uom,
                        A.unit_price,
-                       (CASE WHEN A.status = 2 THEN 'Active'
-                             WHEN A.status = 3 THEN 'Inactive'
-                             ELSE A.status || '- Unknown' END) AS status
+                       CASE
+                           WHEN A.status = 2 THEN 'Active'
+                           WHEN A.status = 3 THEN 'Inactive'
+                           ELSE A.status || '- Unknown'
+                       END AS status
                 FROM inmatm A
-                WHERE (A.mat_cd LIKE :matcode || '%' OR :matcode IS NULL)
-                AND A.status IN (2, 3)
+                WHERE
+                    (:matcode IS NULL OR A.mat_cd LIKE :matcode || '%')
+                AND
+                    (:status IS NULL OR A.status = :status)
+                AND
+                    A.status IN (2,3)
                 ORDER BY A.mat_cd";
+
             using (var conn = new OracleConnection(_connectionString))
             using (var cmd = new OracleCommand(query, conn))
             {
                 cmd.CommandType = CommandType.Text;
                 cmd.BindByName = true;
-                // matCode may be null (blank input = return all records).
-                if (string.IsNullOrWhiteSpace(matCode))
+
+                // Material Code parameter
+                cmd.Parameters.Add(new OracleParameter("matcode", OracleDbType.Varchar2)
                 {
-                    cmd.Parameters.Add(new OracleParameter("matcode", OracleDbType.Varchar2)
-                    {
-                        Value = DBNull.Value
-                    });
-                }
-                else
+                    Value = string.IsNullOrWhiteSpace(matCode)
+                        ? (object)DBNull.Value
+                        : matCode.Trim()
+                });
+
+                // Status parameter
+                cmd.Parameters.Add(new OracleParameter("status", OracleDbType.Int32)
                 {
-                    cmd.Parameters.Add(new OracleParameter("matcode", OracleDbType.Varchar2)
-                    {
-                        Value = matCode.Trim()
-                    });
-                }
+                    Value = status.HasValue
+                        ? (object)status.Value
+                        : DBNull.Value
+                });
 
                 conn.Open();
+
                 using (var reader = cmd.ExecuteReader())
                 {
                     while (reader.Read())
@@ -63,12 +68,15 @@ namespace MISReports_Api.DAL
                             MatCd = reader["mat_cd"] == DBNull.Value ? null : reader["mat_cd"].ToString(),
                             MatNm = reader["mat_nm"] == DBNull.Value ? null : reader["mat_nm"].ToString(),
                             MajUom = reader["maj_uom"] == DBNull.Value ? null : reader["maj_uom"].ToString(),
-                            UnitPrice = reader["unit_price"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["unit_price"]),
+                            UnitPrice = reader["unit_price"] == DBNull.Value
+                                ? (decimal?)null
+                                : Convert.ToDecimal(reader["unit_price"]),
                             Status = reader["status"] == DBNull.Value ? null : reader["status"].ToString()
                         });
                     }
                 }
             }
+
             return result;
         }
     }


### PR DESCRIPTION
Add optional status parameter to GetReport and GetQuery endpoints to filter materials by Active (2) or Inactive (3) status. Includes validation for valid status values, updated SQL query with proper parameter binding, and enhanced response summary. Also cleaned up unused imports and improved code formatting.