### PR TITLE
Add BranchGrnNotGen report API

### DIFF
--- a/Controllers/Inventory/BranchgrnnotgenController.cs
+++ b/Controllers/Inventory/BranchgrnnotgenController.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using MISReports_Api.DAL;
+using MISReports_Api.Models.Accounts;
+namespace MISReports_Api.Controllers
+{
+    [RoutePrefix("api/branchgrnnotgen")]
+    public class BranchGrnNotGenController : ApiController
+    {
+        private readonly BranchGrnNotGenDAL _dal = new BranchGrnNotGenDAL();
+
+        // PATH: /api/branchgrnnotgen/report/2026-01-01/2026-03-31/100
+        [HttpGet]
+        [Route("report/{fromDate}/{toDate}/{compId}")]
+        public IHttpActionResult GetReport(string fromDate, string toDate, string compId)
+        {
+            return ExecuteQuery(fromDate, toDate, compId);
+        }
+
+        // QUERY: /api/branchgrnnotgen/report?fromDate=2026-01-01&toDate=2026-03-31&compId=100
+        [HttpGet]
+        [Route("report")]
+        public IHttpActionResult GetQuery([FromUri] string fromDate, [FromUri] string toDate, [FromUri] string compId)
+        {
+            return ExecuteQuery(fromDate, toDate, compId);
+        }
+
+        private IHttpActionResult ExecuteQuery(string fromDate, string toDate, string compId)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(fromDate) || !DateTime.TryParse(fromDate, out DateTime fromDt))
+                    return BadRequest("fromDate must be a valid date (e.g., 2026-01-01).");
+                if (string.IsNullOrWhiteSpace(toDate) || !DateTime.TryParse(toDate, out DateTime toDt))
+                    return BadRequest("toDate must be a valid date (e.g., 2026-03-31).");
+                if (toDt < fromDt)
+                    return BadRequest("toDate cannot be earlier than fromDate.");
+                if (string.IsNullOrWhiteSpace(compId))
+                    return BadRequest("compId is required.");
+
+                // SQL uses TO_DATE(:param,'yyyy/mm/dd'), so format to match the mask.
+                string fromDateFormatted = fromDt.ToString("yyyy/MM/dd");
+                string toDateFormatted = toDt.ToString("yyyy/MM/dd");
+
+                var data = _dal.GetBranchGrnNotGen(fromDateFormatted, toDateFormatted, compId.Trim());
+                var totalTrxnVal = data.Sum(x => x.TrxnVal ?? 0m);
+
+                const int MAX_RECORDS = 5000;
+                var summary = new
+                {
+                    fromDate = fromDt.ToString("yyyy-MM-dd"),
+                    toDate = toDt.ToString("yyyy-MM-dd"),
+                    compId = compId.Trim(),
+                    totalRecords = data.Count,
+                    totalTrxnVal
+                };
+
+                if (data.Count >= MAX_RECORDS)
+                {
+                    return Ok(new
+                    {
+                        success = false,
+                        message = $"Too many records ({data.Count}). Result capped at {MAX_RECORDS}. Use narrower filters.",
+                        data = new object[0],
+                        summary
+                    });
+                }
+
+                return Ok(new
+                {
+                    success = true,
+                    message = data.Any() ? "Data retrieved successfully" : "No records found",
+                    data,
+                    summary
+                });
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error: {ex.Message}\n{ex.StackTrace}");
+                return InternalServerError(new Exception($"Database error: {ex.Message}", ex));
+            }
+        }
+    }
+}

--- a/DAL/Inventory/Branchgrnnotgendal.cs
+++ b/DAL/Inventory/Branchgrnnotgendal.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Configuration;
+using System.Data;
+using Oracle.ManagedDataAccess.Client;
+using MISReports_Api.Models.Accounts;
+namespace MISReports_Api.DAL
+{
+    public class BranchGrnNotGenDAL
+    {
+        private readonly string _connectionString =
+            ConfigurationManager.ConnectionStrings["HQOracle"].ConnectionString;
+
+        public List<BranchGrnNotGenModel> GetBranchGrnNotGen(string fromDate, string toDate, string compId)
+        {
+            var result = new List<BranchGrnNotGenModel>();
+
+            // Escape single quotes in compId to prevent SQL injection
+            string safeCompId = compId.Replace("'", "''");
+
+            string query = $@"
+        SELECT T2.doc_no, T2.trx_dt, T2.des_dept_id, T2.wrh_cd, T2.ref_1, T2.trxn_val,
+               (SELECT comp_nm FROM glcompm WHERE comp_id = '{safeCompId}') AS CCT_NAME
+        FROM intrhmt T2
+        WHERE T2.Issue_to = 2
+          AND T2.dept_id IN (
+              SELECT dept_id
+              FROM gldeptm
+              WHERE status = 2
+                AND comp_id IN (
+                    SELECT comp_id
+                    FROM glcompm
+                    WHERE comp_id = '{safeCompId}'
+                       OR parent_id = '{safeCompId}'
+                       OR grp_comp = '{safeCompId}'
+                )
+          )
+          AND TO_DATE(:fromdate,'yyyy/mm/dd') <= T2.trx_dt
+          AND TO_DATE(:todate,'yyyy/mm/dd') >= T2.trx_dt
+          AND TRIM(T2.doc_no) NOT IN (
+              SELECT TRIM(ref_2)
+              FROM intrhmt
+              WHERE rc_from = 3
+                AND dept_id = T2.des_dept_id
+          )";
+
+            using (var conn = new OracleConnection(_connectionString))
+            using (var cmd = new OracleCommand(query, conn))
+            {
+                cmd.CommandType = CommandType.Text;
+                cmd.BindByName = true;
+                cmd.Parameters.Add(new OracleParameter("fromdate", OracleDbType.Varchar2) { Value = fromDate });
+                cmd.Parameters.Add(new OracleParameter("todate", OracleDbType.Varchar2) { Value = toDate });
+
+                conn.Open();
+                using (var reader = cmd.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        result.Add(new BranchGrnNotGenModel
+                        {
+                            DocNo = reader["doc_no"] == DBNull.Value ? null : reader["doc_no"].ToString(),
+                            TrxDt = reader["trx_dt"] == DBNull.Value ? (DateTime?)null : Convert.ToDateTime(reader["trx_dt"]),
+                            DesDeptId = reader["des_dept_id"] == DBNull.Value ? null : reader["des_dept_id"].ToString(),
+                            WrhCd = reader["wrh_cd"] == DBNull.Value ? null : reader["wrh_cd"].ToString(),
+                            Ref1 = reader["ref_1"] == DBNull.Value ? null : reader["ref_1"].ToString(),
+                            TrxnVal = reader["trxn_val"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["trxn_val"]),
+                            BranchName = reader["CCT_NAME"] == DBNull.Value ? null : reader["CCT_NAME"].ToString()
+                        });
+                    }
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/MISReports_Api.csproj
+++ b/MISReports_Api.csproj
@@ -361,6 +361,7 @@
     <Compile Include="Controllers\GeneralController.cs" />
     <Compile Include="Controllers\IncomeExpenditure\IncomeExpenditureRegionDetailedController.cs" />
     <Compile Include="Controllers\Inventory\avgConsumptionSelectedController.cs" />
+    <Compile Include="Controllers\Inventory\BranchgrnnotgenController.cs" />
     <Compile Include="Controllers\Inventory\CcgrnnotgenController.cs" />
     <Compile Include="Controllers\Inventory\CcwiseissueController.cs" />
     <Compile Include="Controllers\Inventory\GrnRaisedForPurchasingController.cs" />
@@ -506,6 +507,7 @@
     <Compile Include="DAL\General\SMSRegisteredCustomersOrdinary\RegisteredCustomersBillCycleDao.cs" />
     <Compile Include="DAL\IncomeExpenditure\IncomeExpenditureRegionDetailedRepository.cs" />
     <Compile Include="DAL\Inventory\avgConsumptionSelectedDataRepository.cs" />
+    <Compile Include="DAL\Inventory\Branchgrnnotgendal.cs" />
     <Compile Include="DAL\Inventory\Ccgrnnotgendal.cs" />
     <Compile Include="DAL\Inventory\Ccwiseissuedal.cs" />
     <Compile Include="DAL\Inventory\GrnRaisedForPurchasingDAL.cs" />
@@ -560,6 +562,7 @@
     <Compile Include="Models\BillMapModel.cs" />
     <Compile Include="Models\General\ArrearsPositionModel .cs" />
     <Compile Include="Models\General\FinalizedAccountsModel.cs" />
+    <Compile Include="Models\Inventory\Branchgrnnotgenmodel.cs" />
     <Compile Include="Models\Inventory\Ccgrnnotgenmodel.cs" />
     <Compile Include="Models\Inventory\Ccwiseissuemodel.cs" />
     <Compile Include="Models\Inventory\GrnPeriodSummaryModel.cs" />
@@ -904,6 +907,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />
+    <Folder Include="Views\Branchgrnnotgen\" />
     <Folder Include="Views\Ccgrnnotgen\" />
     <Folder Include="Views\Ccwiseissue\" />
     <Folder Include="Views\ChequeDetailWP\" />

--- a/Models/Inventory/Branchgrnnotgenmodel.cs
+++ b/Models/Inventory/Branchgrnnotgenmodel.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+namespace MISReports_Api.Models.Accounts
+{
+    public class BranchGrnNotGenModel
+    {
+        public string DocNo { get; set; }
+        public DateTime? TrxDt { get; set; }
+        public string DesDeptId { get; set; }
+        public string WrhCd { get; set; }
+        public string Ref1 { get; set; }
+        public decimal? TrxnVal { get; set; }
+        public string BranchName { get; set; }
+    }
+}


### PR DESCRIPTION
Add BranchGrnNotGen report feature: new API controller (Controllers/Inventory/BranchgrnnotgenController.cs) with path/query endpoints and input validation, a DAL (DAL/Inventory/Branchgrnnotgendal.cs) that queries Oracle using bound date params and escapes compId, and a model (Models/Inventory/Branchgrnnotgenmodel.cs). MISReports_Api.csproj updated to include the new files and a Views\Branchgrnnotgen folder. Response includes summary, totalTrxnVal and a 5000-record cap; errors are logged and returned as internal server errors.