### PR TITLE
Add repYear parameter to PHV FIFO report filter

### DIFF
--- a/Controllers/FIFO/PHVObsoleteIdleFIFOController.cs
+++ b/Controllers/FIFO/PHVObsoleteIdleFIFOController.cs
@@ -26,7 +26,8 @@ namespace MISReports_Api.Controllers.FIFO
         [Route("list")]
         public async Task<IHttpActionResult> GetPHVObsoleteIdleFIFO(
             string deptId,
-            string warehouseCode)
+            string warehouseCode,
+            int repYear)
         {
             try
             {
@@ -35,7 +36,8 @@ namespace MISReports_Api.Controllers.FIFO
 
                 var data = await _repository.GetPHVObsoleteIdleFIFOAsync(
                     deptId.Trim(),
-                    warehouseCode.Trim());
+                    warehouseCode.Trim(),
+                    repYear);
 
                 return Json(data);
             }
@@ -74,7 +76,8 @@ namespace MISReports_Api.Controllers.FIFO
 
                 var data = await _repository.GetPHVObsoleteIdleFIFOAsync(
                     deptId.Trim(),
-                    warehouseCode.Trim());
+                    warehouseCode.Trim(),
+                    repYear);
 
                 if (data == null || !data.Any())
                 {
@@ -147,7 +150,8 @@ namespace MISReports_Api.Controllers.FIFO
 
                 var data = await _repository.GetPHVObsoleteIdleFIFOAsync(
                     deptId.Trim(),
-                    warehouseCode.Trim());
+                    warehouseCode.Trim(),
+                    repYear);
 
                 if (data == null || !data.Any())
                 {

--- a/DAL/FIFO/PHVObsoleteIdleFIFORepository.cs
+++ b/DAL/FIFO/PHVObsoleteIdleFIFORepository.cs
@@ -31,7 +31,8 @@ namespace MISReports_Api.DAL.FIFO
 
         public async Task<List<PHVObsoleteIdleFIFOModel>> GetPHVObsoleteIdleFIFOAsync(
             string deptId,
-            string warehouseCode)
+            string warehouseCode,
+            int repYear)
         {
             var result = new List<PHVObsoleteIdleFIFOModel>();
 
@@ -48,7 +49,7 @@ namespace MISReports_Api.DAL.FIFO
                                         (SELECT dept_nm FROM gldeptm WHERE dept_id = :dept_id) AS cct_name
                 FROM fifo_phv f, inmatm m
                 WHERE TRIM(f.mat_cd) = TRIM(m.mat_cd)
-                  AND f.status = 2020
+                  AND f.status = :rep_year
                                     AND TRIM(f.dept_id) = :dept_id
                                     AND TRIM(f.wrh_cd) = :wrh_cd
                 GROUP BY
@@ -68,6 +69,7 @@ namespace MISReports_Api.DAL.FIFO
                 cmd.BindByName = true;
                 cmd.Parameters.Add("dept_id", OracleDbType.Varchar2).Value = deptId.Trim();
                 cmd.Parameters.Add("wrh_cd", OracleDbType.Varchar2).Value = warehouseCode.Trim();
+                cmd.Parameters.Add("rep_Year", OracleDbType.Int32).Value = repYear;
 
                 await conn.OpenAsync();
 


### PR DESCRIPTION
Replace hardcoded status filter value (2020) with a parameterized repYear input. This allows the report year to be dynamically specified when retrieving obsolete idle FIFO data, making the filter configurable instead of hardcoded.