### PR TITLE
Add PHV non-moving warehouse report feature

### DIFF
--- a/Controllers/FIFO/PHVNonMovingWHController.cs
+++ b/Controllers/FIFO/PHVNonMovingWHController.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using MISReports_Api.DAL;
+using MISReports_Api.Models.Accounts;
+namespace MISReports_Api.Controllers
+{
+    [RoutePrefix("api/phvnonmovingwh")]
+    public class PHVNonMovingWHController : ApiController
+    {
+        private readonly PHVNonMovingWHDAL _dal = new PHVNonMovingWHDAL();
+
+        // PATH: /api/phvnonmovingwh/report/2025/WH_CEPP
+        [HttpGet]
+        [Route("report/{repYear:regex(^\\d{4}$)}/{whCode}")]
+        public IHttpActionResult GetReport(string repYear, string whCode)
+        {
+            return ExecuteQuery(repYear, whCode);
+        }
+
+        // QUERY: /api/phvnonmovingwh/report?repYear=2025&whCode=WH_CEPP
+        [HttpGet]
+        [Route("report")]
+        public IHttpActionResult GetQuery([FromUri] string repYear, [FromUri] string whCode)
+        {
+            return ExecuteQuery(repYear, whCode);
+        }
+
+        private IHttpActionResult ExecuteQuery(string repYear, string whCode)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(repYear) || repYear.Length != 4 || !int.TryParse(repYear, out _))
+                    return BadRequest("repYear must be a 4-digit year (e.g., 2025).");
+                if (string.IsNullOrWhiteSpace(whCode))
+                    return BadRequest("whCode is required.");
+
+                var data = _dal.GetPHVNonMovingWH(repYear.Trim(), whCode.Trim());
+                var totalStockBook = data.Sum(x => x.StockBook ?? 0m);
+
+                const int MAX_RECORDS = 5000;
+                var summary = new
+                {
+                    repYear = repYear.Trim(),
+                    whCode = whCode.Trim(),
+                    totalRecords = data.Count,
+                    totalStockBook
+                };
+
+                if (data.Count >= MAX_RECORDS)
+                {
+                    return Ok(new
+                    {
+                        success = false,
+                        message = $"Too many records ({data.Count}). Result capped at {MAX_RECORDS}. Use narrower filters.",
+                        data = new object[0],
+                        summary
+                    });
+                }
+
+                return Ok(new
+                {
+                    success = true,
+                    message = data.Any() ? "Data retrieved successfully" : "No records found",
+                    data,
+                    summary
+                });
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error: {ex.Message}\n{ex.StackTrace}");
+                return InternalServerError(new Exception($"Database error: {ex.Message}", ex));
+            }
+        }
+    }
+}

--- a/DAL/FIFO/PHVNonMovingWHDAL.cs
+++ b/DAL/FIFO/PHVNonMovingWHDAL.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Configuration;
+using System.Data;
+using Oracle.ManagedDataAccess.Client;
+using MISReports_Api.Models.Accounts;
+namespace MISReports_Api.DAL
+{
+    public class PHVNonMovingWHDAL
+    {
+        private readonly string _connectionString =
+            ConfigurationManager.ConnectionStrings["HQOracle"].ConnectionString;
+
+        public List<PHVNonMovingWHModel> GetPHVNonMovingWH(string repYear, string whCode)
+        {
+            var result = new List<PHVNonMovingWHModel>();
+            const string query = @"
+                SELECT F.doc_no, F.mat_cd, M.mat_nm, F.grade_cd, F.doc_dt AS phv_dt,
+                       SUM(CASE WHEN F.damage_count > 0 THEN F.damage_count ELSE F.counted_qty END) AS qty_on_hand,
+                       SUM(F.unit_price * (CASE WHEN F.damage_count > 0 THEN F.damage_count ELSE F.counted_qty END)) AS stockbook,
+                       F.reason,
+                       (SELECT dept_nm FROM gldeptm WHERE dept_id = SUBSTR(F.doc_no,0,6)) AS CCT_NAME
+                FROM fifo_phv F, inmatm M
+                WHERE TRIM(F.mat_cd) = TRIM(M.mat_cd)
+                  AND F.moving_status = 2
+                  AND F.dept_id = SUBSTR(F.doc_no,0,6)
+                  AND F.status = :repyear
+                  AND F.wrh_cd = :whcode
+                GROUP BY F.doc_no, F.mat_cd, M.mat_nm, F.grade_cd, F.reason, F.doc_dt
+                ORDER BY F.doc_no, F.mat_cd";
+
+            using (var conn = new OracleConnection(_connectionString))
+            using (var cmd = new OracleCommand(query, conn))
+            {
+                cmd.CommandType = CommandType.Text;
+                cmd.BindByName = true;
+                cmd.Parameters.Add(new OracleParameter("repyear", OracleDbType.Varchar2) { Value = repYear });
+                cmd.Parameters.Add(new OracleParameter("whcode", OracleDbType.Varchar2) { Value = whCode });
+
+                conn.Open();
+                using (var reader = cmd.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        result.Add(new PHVNonMovingWHModel
+                        {
+                            DocNo = reader["doc_no"] == DBNull.Value ? null : reader["doc_no"].ToString(),
+                            MatCd = reader["mat_cd"] == DBNull.Value ? null : reader["mat_cd"].ToString(),
+                            MatNm = reader["mat_nm"] == DBNull.Value ? null : reader["mat_nm"].ToString(),
+                            GradeCd = reader["grade_cd"] == DBNull.Value ? null : reader["grade_cd"].ToString(),
+                            PhvDt = reader["phv_dt"] == DBNull.Value ? (DateTime?)null : Convert.ToDateTime(reader["phv_dt"]),
+                            QtyOnHand = reader["qty_on_hand"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["qty_on_hand"]),
+                            StockBook = reader["stockbook"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["stockbook"]),
+                            Reason = reader["reason"] == DBNull.Value ? null : reader["reason"].ToString(),
+                            CctName = reader["CCT_NAME"] == DBNull.Value ? null : reader["CCT_NAME"].ToString()
+                        });
+                    }
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/MISReports_Api.csproj
+++ b/MISReports_Api.csproj
@@ -357,6 +357,7 @@
     <Compile Include="Controllers\DashboardController.cs" />
     <Compile Include="Controllers\CustomerDetailsController.cs" />
     <Compile Include="Controllers\DgmDashboard\DgmDashboardController.cs" />
+    <Compile Include="Controllers\FIFO\PHVNonMovingWHController.cs" />
     <Compile Include="Controllers\FIFO\PHVSlowMovingWHController.cs" />
     <Compile Include="Controllers\FinancialDashboardController.cs" />
     <Compile Include="Controllers\GeneralController.cs" />
@@ -491,6 +492,7 @@
     <Compile Include="DAL\DgmDashboard\DgmStockValueDao.cs" />
     <Compile Include="DAL\DgmDashboard\DgmAppCountDao.cs" />
     <Compile Include="DAL\DgmDashboard\DgmConnectionGivenDao.cs" />
+    <Compile Include="DAL\FIFO\PHVNonMovingWHDAL.cs" />
     <Compile Include="DAL\FIFO\PHVSlowMovingWHDAL.cs" />
     <Compile Include="DAL\FinancialDashboard\PivDivisionDao.cs" />
     <Compile Include="DAL\FinancialDashboard\PivTotalDao.cs" />
@@ -562,6 +564,7 @@
     <Compile Include="Models\DgmDashboard\DgmAppCountModel.cs" />
     <Compile Include="Models\DgmDashboard\DgmConnectionGivenModel.cs" />
     <Compile Include="Models\BillMapModel.cs" />
+    <Compile Include="Models\FIFO\PHVNonMovingWHModel.cs" />
     <Compile Include="Models\FIFO\PHVSlowMovingWHModel.cs" />
     <Compile Include="Models\General\ArrearsPositionModel .cs" />
     <Compile Include="Models\General\FinalizedAccountsModel.cs" />
@@ -918,6 +921,7 @@
     <Folder Include="Views\IssueReceiptWP\" />
     <Folder Include="Views\IssuesRaisedForJobs\" />
     <Folder Include="Views\MaterialMaster\" />
+    <Folder Include="Views\PHVNonMovingWH\" />
     <Folder Include="Views\PHVSlowMovingWH\" />
   </ItemGroup>
   <ItemGroup>

--- a/Models/FIFO/PHVNonMovingWHModel.cs
+++ b/Models/FIFO/PHVNonMovingWHModel.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+namespace MISReports_Api.Models.Accounts
+{
+    public class PHVNonMovingWHModel
+    {
+        public string DocNo { get; set; }
+        public string MatCd { get; set; }
+        public string MatNm { get; set; }
+        public string GradeCd { get; set; }
+        public DateTime? PhvDt { get; set; }
+        public decimal? QtyOnHand { get; set; }
+        public decimal? StockBook { get; set; }
+        public string Reason { get; set; }
+        public string CctName { get; set; }
+    }
+}


### PR DESCRIPTION
Add API endpoints, data access layer, and model for retrieving PHV (Physical Verification) non-moving warehouse reports. Includes support for both route-based and query-based endpoints, input validation, database queries with filtering by year and warehouse code, and summary statistics (total records and stock book value).