### PR TITLE
Add PHV Damage BOS report (controller, DAL, model)

### DIFF
--- a/Controllers/FIFO/PHVDamageBOSController.cs
+++ b/Controllers/FIFO/PHVDamageBOSController.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using MISReports_Api.DAL;
+using MISReports_Api.Models.Accounts;
+namespace MISReports_Api.Controllers
+{
+    [RoutePrefix("api/phvdamagebos")]
+    public class PHVDamageBOSController : ApiController
+    {
+        private readonly PHVDamageBOSDAL _dal = new PHVDamageBOSDAL();
+
+        // PATH: /api/phvdamagebos/report/2025/WH_CELIFT
+        [HttpGet]
+        [Route("report/{repYear:regex(^\\d{4}$)}/{whCode}")]
+        public IHttpActionResult GetReport(string repYear, string whCode)
+        {
+            return ExecuteQuery(repYear, whCode);
+        }
+
+        // QUERY: /api/phvdamagebos/report?repYear=2025&whCode=WH_CELIFT
+        [HttpGet]
+        [Route("report")]
+        public IHttpActionResult GetQuery([FromUri] string repYear, [FromUri] string whCode)
+        {
+            return ExecuteQuery(repYear, whCode);
+        }
+
+        private IHttpActionResult ExecuteQuery(string repYear, string whCode)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(repYear) || repYear.Length != 4 || !int.TryParse(repYear, out _))
+                    return BadRequest("repYear must be a 4-digit year (e.g., 2025).");
+                if (string.IsNullOrWhiteSpace(whCode))
+                    return BadRequest("whCode is required.");
+
+                var data = _dal.GetPHVDamageBOS(repYear.Trim(), whCode.Trim());
+                var totalStockBook = data.Sum(x => x.StockBook ?? 0m);
+
+                const int MAX_RECORDS = 5000;
+                var summary = new
+                {
+                    repYear = repYear.Trim(),
+                    whCode = whCode.Trim(),
+                    totalRecords = data.Count,
+                    totalStockBook
+                };
+
+                if (data.Count >= MAX_RECORDS)
+                {
+                    return Ok(new
+                    {
+                        success = false,
+                        message = $"Too many records ({data.Count}). Result capped at {MAX_RECORDS}. Use narrower filters.",
+                        data = new object[0],
+                        summary
+                    });
+                }
+
+                return Ok(new
+                {
+                    success = true,
+                    message = data.Any() ? "Data retrieved successfully" : "No records found",
+                    data,
+                    summary
+                });
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error: {ex.Message}\n{ex.StackTrace}");
+                return InternalServerError(new Exception($"Database error: {ex.Message}", ex));
+            }
+        }
+    }
+}

--- a/DAL/FIFO/PHVDamageBOSDAL.cs
+++ b/DAL/FIFO/PHVDamageBOSDAL.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Configuration;
+using System.Data;
+using Oracle.ManagedDataAccess.Client;
+using MISReports_Api.Models.Accounts;
+namespace MISReports_Api.DAL
+{
+    public class PHVDamageBOSDAL
+    {
+        private readonly string _connectionString =
+            ConfigurationManager.ConnectionStrings["HQOracle"].ConnectionString;
+
+        public List<PHVDamageBOSModel> GetPHVDamageBOS(string repYear, string whCode)
+        {
+            var result = new List<PHVDamageBOSModel>();
+            const string query = @"
+                SELECT F.doc_no, F.mat_cd, M.mat_nm, F.grade_cd, F.damage_count, F.batch_id,
+                       (CASE WHEN F.damage_count > 0 THEN F.damage_count ELSE F.counted_qty END) AS qty_on_hand,
+                       F.unit_price,
+                       (F.unit_price * F.damage_count) AS stockbook,
+                       F.reason,
+                       (SELECT dept_nm FROM gldeptm WHERE dept_id = SUBSTR(F.doc_no,0,6)) AS CCT_NAME
+                FROM fifo_phv F, inmatm M
+                WHERE TRIM(F.mat_cd) = TRIM(M.mat_cd)
+                  AND (F.damage_count > 0 OR TRIM(F.grade_cd) = 'DAM' OR TRIM(F.grade_cd) = 'DMG')
+                  AND F.dept_id = SUBSTR(F.doc_no,0,6)
+                  AND F.status = :repyear
+                  AND F.wrh_cd = :whcode
+                ORDER BY F.doc_no, F.mat_cd";
+
+            using (var conn = new OracleConnection(_connectionString))
+            using (var cmd = new OracleCommand(query, conn))
+            {
+                cmd.CommandType = CommandType.Text;
+                cmd.BindByName = true;
+                cmd.Parameters.Add(new OracleParameter("repyear", OracleDbType.Varchar2) { Value = repYear });
+                cmd.Parameters.Add(new OracleParameter("whcode", OracleDbType.Varchar2) { Value = whCode });
+
+                conn.Open();
+                using (var reader = cmd.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        result.Add(new PHVDamageBOSModel
+                        {
+                            DocNo = reader["doc_no"] == DBNull.Value ? null : reader["doc_no"].ToString(),
+                            MatCd = reader["mat_cd"] == DBNull.Value ? null : reader["mat_cd"].ToString(),
+                            MatNm = reader["mat_nm"] == DBNull.Value ? null : reader["mat_nm"].ToString(),
+                            GradeCd = reader["grade_cd"] == DBNull.Value ? null : reader["grade_cd"].ToString(),
+                            DamageCount = reader["damage_count"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["damage_count"]),
+                            BatchId = reader["batch_id"] == DBNull.Value ? null : reader["batch_id"].ToString(),
+                            QtyOnHand = reader["qty_on_hand"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["qty_on_hand"]),
+                            UnitPrice = reader["unit_price"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["unit_price"]),
+                            StockBook = reader["stockbook"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["stockbook"]),
+                            Reason = reader["reason"] == DBNull.Value ? null : reader["reason"].ToString(),
+                            CctName = reader["CCT_NAME"] == DBNull.Value ? null : reader["CCT_NAME"].ToString()
+                        });
+                    }
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/MISReports_Api.csproj
+++ b/MISReports_Api.csproj
@@ -357,7 +357,9 @@
     <Compile Include="Controllers\DashboardController.cs" />
     <Compile Include="Controllers\CustomerDetailsController.cs" />
     <Compile Include="Controllers\DgmDashboard\DgmDashboardController.cs" />
+    <Compile Include="Controllers\FIFO\PHVDamageBOSController.cs" />
     <Compile Include="Controllers\FIFO\PHVNonMovingWHController.cs" />
+    <Compile Include="Controllers\FIFO\PHVObsoleteBOSController.cs" />
     <Compile Include="Controllers\FIFO\PHVSlowMovingWHController.cs" />
     <Compile Include="Controllers\FinancialDashboardController.cs" />
     <Compile Include="Controllers\GeneralController.cs" />
@@ -492,7 +494,9 @@
     <Compile Include="DAL\DgmDashboard\DgmStockValueDao.cs" />
     <Compile Include="DAL\DgmDashboard\DgmAppCountDao.cs" />
     <Compile Include="DAL\DgmDashboard\DgmConnectionGivenDao.cs" />
+    <Compile Include="DAL\FIFO\PHVDamageBOSDAL.cs" />
     <Compile Include="DAL\FIFO\PHVNonMovingWHDAL.cs" />
+    <Compile Include="DAL\FIFO\PHVObsoleteBOSDAL.cs" />
     <Compile Include="DAL\FIFO\PHVSlowMovingWHDAL.cs" />
     <Compile Include="DAL\FinancialDashboard\PivDivisionDao.cs" />
     <Compile Include="DAL\FinancialDashboard\PivTotalDao.cs" />
@@ -564,7 +568,9 @@
     <Compile Include="Models\DgmDashboard\DgmAppCountModel.cs" />
     <Compile Include="Models\DgmDashboard\DgmConnectionGivenModel.cs" />
     <Compile Include="Models\BillMapModel.cs" />
+    <Compile Include="Models\FIFO\PHVDamageBOSModel.cs" />
     <Compile Include="Models\FIFO\PHVNonMovingWHModel.cs" />
+    <Compile Include="Models\FIFO\PHVObsoleteBOSModel.cs" />
     <Compile Include="Models\FIFO\PHVSlowMovingWHModel.cs" />
     <Compile Include="Models\General\ArrearsPositionModel .cs" />
     <Compile Include="Models\General\FinalizedAccountsModel.cs" />
@@ -921,7 +927,10 @@
     <Folder Include="Views\IssueReceiptWP\" />
     <Folder Include="Views\IssuesRaisedForJobs\" />
     <Folder Include="Views\MaterialMaster\" />
+    <Folder Include="Views\PHVDamageBOS\" />
+    <Folder Include="Views\PHVDamageBSO\" />
     <Folder Include="Views\PHVNonMovingWH\" />
+    <Folder Include="Views\PHVObsoleteIdleBOS\" />
     <Folder Include="Views\PHVSlowMovingWH\" />
   </ItemGroup>
   <ItemGroup>

--- a/Models/FIFO/PHVDamageBOSModel.cs
+++ b/Models/FIFO/PHVDamageBOSModel.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+namespace MISReports_Api.Models.Accounts
+{
+    public class PHVDamageBOSModel
+    {
+        public string DocNo { get; set; }
+        public string MatCd { get; set; }
+        public string MatNm { get; set; }
+        public string GradeCd { get; set; }
+        public decimal? DamageCount { get; set; }
+        public string BatchId { get; set; }
+        public decimal? QtyOnHand { get; set; }
+        public decimal? UnitPrice { get; set; }
+        public decimal? StockBook { get; set; }
+        public string Reason { get; set; }
+        public string CctName { get; set; }
+    }
+}


### PR DESCRIPTION
Introduce PHVDamageBOS feature: adds API controller, DAL and model to provide PHV damage BOS reports. Controller exposes GET /api/phvdamagebos/report/{repYear}/{whCode} and query-string variant, validates inputs, returns data + summary and enforces a 5000-record cap. DAL implements Oracle query (uses HQOracle connection string) to fetch fields including stockbook calculation and CCT_NAME. Adds PHVDamageBOSModel to represent result rows. Project file updated to include new source files and view folders. Error handling and basic logging included.