### PR TITLE
Add PHVObsoleteBOS API, DAL and model

### DIFF
--- a/Controllers/FIFO/PHVObsoleteBOSController.cs
+++ b/Controllers/FIFO/PHVObsoleteBOSController.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using MISReports_Api.DAL;
+using MISReports_Api.Models.Accounts;
+namespace MISReports_Api.Controllers
+{
+    [RoutePrefix("api/phvobsoletebos")]
+    public class PHVObsoleteBOSController : ApiController
+    {
+        private readonly PHVObsoleteBOSDAL _dal = new PHVObsoleteBOSDAL();
+
+        // PATH: /api/phvobsoletebos/report/2025/WH_CELIFT
+        [HttpGet]
+        [Route("report/{repYear:regex(^\\d{4}$)}/{whCode}")]
+        public IHttpActionResult GetReport(string repYear, string whCode)
+        {
+            return ExecuteQuery(repYear, whCode);
+        }
+
+        // QUERY: /api/phvobsoletebos/report?repYear=2025&whCode=WH_CELIFT
+        [HttpGet]
+        [Route("report")]
+        public IHttpActionResult GetQuery([FromUri] string repYear, [FromUri] string whCode)
+        {
+            return ExecuteQuery(repYear, whCode);
+        }
+
+        private IHttpActionResult ExecuteQuery(string repYear, string whCode)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(repYear) || repYear.Length != 4 || !int.TryParse(repYear, out _))
+                    return BadRequest("repYear must be a 4-digit year (e.g., 2025).");
+                if (string.IsNullOrWhiteSpace(whCode))
+                    return BadRequest("whCode is required.");
+
+                var data = _dal.GetPHVObsoleteBOS(repYear.Trim(), whCode.Trim());
+                var totalStockBook = data.Sum(x => x.StockBook ?? 0m);
+
+                const int MAX_RECORDS = 5000;
+                var summary = new
+                {
+                    repYear = repYear.Trim(),
+                    whCode = whCode.Trim(),
+                    totalRecords = data.Count,
+                    totalStockBook
+                };
+
+                if (data.Count >= MAX_RECORDS)
+                {
+                    return Ok(new
+                    {
+                        success = false,
+                        message = $"Too many records ({data.Count}). Result capped at {MAX_RECORDS}. Use narrower filters.",
+                        data = new object[0],
+                        summary
+                    });
+                }
+
+                return Ok(new
+                {
+                    success = true,
+                    message = data.Any() ? "Data retrieved successfully" : "No records found",
+                    data,
+                    summary
+                });
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error: {ex.Message}\n{ex.StackTrace}");
+                return InternalServerError(new Exception($"Database error: {ex.Message}", ex));
+            }
+        }
+    }
+}

--- a/DAL/FIFO/PHVObsoleteBOSDAL.cs
+++ b/DAL/FIFO/PHVObsoleteBOSDAL.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Configuration;
+using System.Data;
+using Oracle.ManagedDataAccess.Client;
+using MISReports_Api.Models.Accounts;
+namespace MISReports_Api.DAL
+{
+    public class PHVObsoleteBOSDAL
+    {
+        private readonly string _connectionString =
+            ConfigurationManager.ConnectionStrings["HQOracle"].ConnectionString;
+
+        public List<PHVObsoleteBOSModel> GetPHVObsoleteBOS(string repYear, string whCode)
+        {
+            var result = new List<PHVObsoleteBOSModel>();
+            const string query = @"
+                SELECT F.doc_no, F.mat_cd, M.mat_nm, F.grade_cd, F.damage_count, F.batch_id,
+                       F.counted_qty AS qty_on_hand,
+                       F.unit_price,
+                       (F.unit_price * F.counted_qty) AS stockbook,
+                       F.reason,
+                       (SELECT dept_nm FROM gldeptm WHERE dept_id = SUBSTR(F.doc_no,0,6)) AS CCT_NAME
+                FROM fifo_phv F, inmatm M
+                WHERE TRIM(F.mat_cd) = TRIM(M.mat_cd)
+                  AND (F.moving_status = 3 OR F.grade_cd IN ('OB','OBS'))
+                  AND F.dept_id = SUBSTR(F.doc_no,0,6)
+                  AND F.status = :repyear
+                  AND F.wrh_cd = :whcode
+                ORDER BY F.doc_no, F.mat_cd";
+
+            using (var conn = new OracleConnection(_connectionString))
+            using (var cmd = new OracleCommand(query, conn))
+            {
+                cmd.CommandType = CommandType.Text;
+                cmd.BindByName = true;
+                cmd.Parameters.Add(new OracleParameter("repyear", OracleDbType.Varchar2) { Value = repYear });
+                cmd.Parameters.Add(new OracleParameter("whcode", OracleDbType.Varchar2) { Value = whCode });
+
+                conn.Open();
+                using (var reader = cmd.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        result.Add(new PHVObsoleteBOSModel
+                        {
+                            DocNo = reader["doc_no"] == DBNull.Value ? null : reader["doc_no"].ToString(),
+                            MatCd = reader["mat_cd"] == DBNull.Value ? null : reader["mat_cd"].ToString(),
+                            MatNm = reader["mat_nm"] == DBNull.Value ? null : reader["mat_nm"].ToString(),
+                            GradeCd = reader["grade_cd"] == DBNull.Value ? null : reader["grade_cd"].ToString(),
+                            DamageCount = reader["damage_count"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["damage_count"]),
+                            BatchId = reader["batch_id"] == DBNull.Value ? null : reader["batch_id"].ToString(),
+                            QtyOnHand = reader["qty_on_hand"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["qty_on_hand"]),
+                            UnitPrice = reader["unit_price"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["unit_price"]),
+                            StockBook = reader["stockbook"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["stockbook"]),
+                            Reason = reader["reason"] == DBNull.Value ? null : reader["reason"].ToString(),
+                            CctName = reader["CCT_NAME"] == DBNull.Value ? null : reader["CCT_NAME"].ToString()
+                        });
+                    }
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/Models/FIFO/PHVObsoleteBOSModel.cs
+++ b/Models/FIFO/PHVObsoleteBOSModel.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+namespace MISReports_Api.Models.Accounts
+{
+    public class PHVObsoleteBOSModel
+    {
+        public string DocNo { get; set; }
+        public string MatCd { get; set; }
+        public string MatNm { get; set; }
+        public string GradeCd { get; set; }
+        public decimal? DamageCount { get; set; }
+        public string BatchId { get; set; }
+        public decimal? QtyOnHand { get; set; }
+        public decimal? UnitPrice { get; set; }
+        public decimal? StockBook { get; set; }
+        public string Reason { get; set; }
+        public string CctName { get; set; }
+    }
+}


### PR DESCRIPTION
Introduce PHVObsoleteBOS endpoint and supporting data layer/model. Adds PHVObsoleteBOSController with routes /api/phvobsoletebos/report/{repYear}/{whCode} and query-string variant; validates repYear (4-digit) and whCode, returns data plus summary and caps results at 5000 records. Adds PHVObsoleteBOSDAL which queries Oracle (HQOracle connection) joining fifo_phv and inmatm with bound parameters. Adds PHVObsoleteBOSModel representing returned fields. Includes basic error handling and debug logging.