### PR TITLE
Add region/province scoped filtering to bulk Areas and Province endpoints

### DIFF
--- a/Controllers/SharedController.cs
+++ b/Controllers/SharedController.cs
@@ -72,7 +72,7 @@ namespace MISReports_Api.Controllers
 
         [HttpGet]
         [Route("bulk/areas")]
-        public IHttpActionResult GetBulkAreas()
+        public IHttpActionResult GetBulkAreas([FromUri] string regionCode = null, [FromUri] string provCode = null)
         {
             try
             {
@@ -86,7 +86,7 @@ namespace MISReports_Api.Controllers
                     }));
                 }
 
-                var areas = _areasDao.GetAreas();
+                var areas = _areasDao.GetAreas(regionCode, provCode);
 
                 return Ok(JObject.FromObject(new
                 {
@@ -107,7 +107,7 @@ namespace MISReports_Api.Controllers
 
         [HttpGet]
         [Route("bulk/province")]
-        public IHttpActionResult GetProvince()
+        public IHttpActionResult GetProvince([FromUri] string regionCode = null)
         {
             try
             {
@@ -121,7 +121,7 @@ namespace MISReports_Api.Controllers
                     }));
                 }
 
-                var province = _provinceDao.GetProvince();
+                var province = _provinceDao.GetProvince(regionCode);
 
                 return Ok(JObject.FromObject(new
                 {

--- a/DAL/Shared/AreasDao.cs
+++ b/DAL/Shared/AreasDao.cs
@@ -15,7 +15,11 @@ namespace MISReports_Api.DAL.Shared
             return _dbConnection.TestConnection(out errorMessage);
         }
 
-        public List<AreaBulkModel> GetAreas()
+        // regionCode / provCode are optional. When provided, results are scoped
+        // to that region or province (used for level-based access restriction).
+        // Leaving both null preserves the original unrestricted behaviour used
+        // by every other report calling this method.
+        public List<AreaBulkModel> GetAreas(string regionCode = null, string provCode = null)
         {
             var areasList = new List<AreaBulkModel>();
 
@@ -25,20 +29,36 @@ namespace MISReports_Api.DAL.Shared
                 {
                     conn.Open();
 
-                    string sql = "SELECT area_code, area_name FROM areas ORDER BY area_name";
+                    string sql = "SELECT area_code, area_name, prov_code, region FROM areas";
+
+                    if (!string.IsNullOrWhiteSpace(regionCode))
+                        sql += " WHERE region = ?";
+                    else if (!string.IsNullOrWhiteSpace(provCode))
+                        sql += " WHERE prov_code = ?";
+
+                    sql += " ORDER BY area_name";
 
                     using (var cmd = new OleDbCommand(sql, conn))
-                    using (var reader = cmd.ExecuteReader())
                     {
-                        while (reader.Read())
-                        {
-                            var area = new AreaBulkModel
-                            {
-                                AreaCode = reader[0]?.ToString().Trim(),
-                                AreaName = reader[1]?.ToString().Trim()
-                            };
+                        if (!string.IsNullOrWhiteSpace(regionCode))
+                            cmd.Parameters.AddWithValue("?", regionCode);
+                        else if (!string.IsNullOrWhiteSpace(provCode))
+                            cmd.Parameters.AddWithValue("?", provCode);
 
-                            areasList.Add(area);
+                        using (var reader = cmd.ExecuteReader())
+                        {
+                            while (reader.Read())
+                            {
+                                var area = new AreaBulkModel
+                                {
+                                    AreaCode = reader[0]?.ToString().Trim(),
+                                    AreaName = reader[1]?.ToString().Trim(),
+                                    ProvCode = reader[2]?.ToString().Trim(),
+                                    Region = reader[3]?.ToString().Trim()
+                                };
+
+                                areasList.Add(area);
+                            }
                         }
                     }
                 }

--- a/DAL/Shared/ProvinceDao.cs
+++ b/DAL/Shared/ProvinceDao.cs
@@ -15,7 +15,13 @@ namespace MISReports_Api.DAL.Shared
             return _dbConnection.TestConnection(out errorMessage);
         }
 
-        public List<ProvinceModel> GetProvince()
+        // regionCode is optional. When provided, only provinces that have at
+        // least one area within that region are returned (used for level-based
+        // access restriction). provinces has no region column itself, so we
+        // join through areas (which carries both prov_code and region) to
+        // find the matching provinces. Leaving regionCode null preserves the
+        // original unrestricted behaviour used by every other report.
+        public List<ProvinceModel> GetProvince(string regionCode = null)
         {
             var provinceList = new List<ProvinceModel>();
 
@@ -25,20 +31,37 @@ namespace MISReports_Api.DAL.Shared
                 {
                     conn.Open();
 
-                    string sql = "SELECT prov_code,prov_name FROM provinces ORDER BY prov_name";
+                    string sql;
+                    if (!string.IsNullOrWhiteSpace(regionCode))
+                    {
+                        sql = "SELECT DISTINCT p.prov_code, p.prov_name " +
+                              "FROM provinces p, areas a " +
+                              "WHERE p.prov_code = a.prov_code " +
+                              "AND a.region = ? " +
+                              "ORDER BY p.prov_name";
+                    }
+                    else
+                    {
+                        sql = "SELECT prov_code,prov_name FROM provinces ORDER BY prov_name";
+                    }
 
                     using (var cmd = new OleDbCommand(sql, conn))
-                    using (var reader = cmd.ExecuteReader())
                     {
-                        while (reader.Read())
-                        {
-                            var province = new ProvinceModel
-                            {
-                                ProvinceCode = reader[0]?.ToString().Trim(),
-                                ProvinceName = reader[1]?.ToString().Trim()
-                            };
+                        if (!string.IsNullOrWhiteSpace(regionCode))
+                            cmd.Parameters.AddWithValue("?", regionCode);
 
-                            provinceList.Add(province);
+                        using (var reader = cmd.ExecuteReader())
+                        {
+                            while (reader.Read())
+                            {
+                                var province = new ProvinceModel
+                                {
+                                    ProvinceCode = reader[0]?.ToString().Trim(),
+                                    ProvinceName = reader[1]?.ToString().Trim()
+                                };
+
+                                provinceList.Add(province);
+                            }
                         }
                     }
                 }

--- a/Models/SolarInformation/AreaBulkModel.cs
+++ b/Models/SolarInformation/AreaBulkModel.cs
@@ -4,6 +4,8 @@
     {
         public string AreaCode { get; set; }
         public string AreaName { get; set; }
+        public string ProvCode { get; set; }
+        public string Region { get; set; }
         public string ErrorMessage { get; set; }
     }
 }


### PR DESCRIPTION
## What this does

Extends the same level-based scoping already added to the ordinary endpoints to their bulk counterparts, so bulk-side reports can also filter areas/provinces by region or province when needed.

## Endpoints changed

- `GET /api/bulk/areas`
  - New optional query params: `regionCode`, `provCode`
  - No params → returns all areas (unchanged behaviour)
  - `?regionCode=R2` → only areas where `region = 'R2'`
  - `?provCode=5` → only areas where `prov_code = '5'`

- `GET /api/bulk/province`
  - New optional query param: `regionCode`
  - No param → returns all provinces (unchanged behaviour)
  - `?regionCode=R2` → only provinces with at least one area in region R2 (joins `provinces` with `areas` on `prov_code`, filtered by `area.region`)

## Why backward compatible

All new parameters default to `null`. Existing callers (`AnalysisController`, `CollectionController`) call these with no query string, so they continue to get the full unrestricted list exactly as before.

## Model change

- `AreaBulkModel` now also returns `ProvCode` and `Region` alongside the 
  existing `AreaCode`/`AreaName`. Additive only — won't break existing consumers.

## Context

Mirrors the same change already merged for the ordinary-side endpoints (`ordinary/areas`, `ordinary/province`) as part of the Roof Top Solar Input Data level-based access work. The Roof Top Solar report itself only queries the ordinary connection, so this bulk change is preparatory — it keeps the pattern consistent in case a bulk variant of this report, or another bulk report, needs the same scoping later.

## Testing done

- Confirmed unfiltered calls to both endpoints still return full lists.
- Confirmed `?regionCode=R2` on both endpoints returns only R2's areas/provinces.
- Confirmed `?provCode=5` on the areas endpoint returns only that province's areas.