### PR TITLE
Add image upload and description/path fields

### DIFF
--- a/Controllers/Admin/Report_Entry/ReportEntryController.cs
+++ b/Controllers/Admin/Report_Entry/ReportEntryController.cs
@@ -3,6 +3,11 @@ using MISReports_Api.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web;
 using System.Web.Http;
 
 namespace MISReports_Api.Controllers
@@ -234,6 +239,139 @@ namespace MISReports_Api.Controllers
                     errorMessage = "Cannot delete report entry.",
                     errorDetails = ex.Message
                 }));
+            }
+        }
+
+        [HttpPost]
+        [Route("upload")]
+        public async Task<IHttpActionResult> UploadSampleImage()
+        {
+            try
+            {
+                if (!Request.Content.IsMimeMultipartContent())
+                {
+                    return Ok(JObject.FromObject(new
+                    {
+                        data = (object)null,
+                        errorMessage = "Unsupported media type. Expected multipart/form-data."
+                    }));
+                }
+
+                var provider = new MultipartMemoryStreamProvider();
+                await Request.Content.ReadAsMultipartAsync(provider);
+
+                var fileContent = provider.Contents.FirstOrDefault(c => !string.IsNullOrEmpty(c.Headers?.ContentDisposition?.FileName));
+                if (fileContent == null)
+                {
+                    return Ok(JObject.FromObject(new
+                    {
+                        data = (object)null,
+                        errorMessage = "No file uploaded."
+                    }));
+                }
+
+                string rawFileName = fileContent.Headers.ContentDisposition.FileName.Trim('\"');
+                string extension = Path.GetExtension(rawFileName)?.ToLowerInvariant();
+
+                if (string.IsNullOrEmpty(extension) || (extension != ".png" && extension != ".jpg" && extension != ".jpeg"))
+                {
+                    return Ok(JObject.FromObject(new
+                    {
+                        data = (object)null,
+                        errorMessage = "Only PNG, JPG, and JPEG image files are allowed."
+                    }));
+                }
+
+                string repId = HttpContext.Current?.Request?.Form["repId"] ?? HttpContext.Current?.Request?.QueryString["repId"];
+                if (string.IsNullOrWhiteSpace(repId))
+                {
+                    return Ok(JObject.FromObject(new
+                    {
+                        data = (object)null,
+                        errorMessage = "Report ID (repId) is required."
+                    }));
+                }
+
+                repId = NormalizeRepId(repId);
+                string newFileName = $"{repId}{extension}";
+
+                string sampleReportsDir = ResolveSampleReportsDirectory();
+                if (!Directory.Exists(sampleReportsDir))
+                {
+                    Directory.CreateDirectory(sampleReportsDir);
+                }
+
+                foreach (var ext in new[] { ".png", ".jpg", ".jpeg" })
+                {
+                    string existingFile = Path.Combine(sampleReportsDir, $"{repId}{ext}");
+                    if (File.Exists(existingFile))
+                    {
+                        try { File.Delete(existingFile); } catch { }
+                    }
+                }
+
+                string destinationPath = Path.Combine(sampleReportsDir, newFileName);
+                byte[] fileBytes = await fileContent.ReadAsByteArrayAsync();
+                File.WriteAllBytes(destinationPath, fileBytes);
+
+                string generatedPath = $"src/assets/SampleReports/{newFileName}";
+
+                return Ok(JObject.FromObject(new
+                {
+                    data = new
+                    {
+                        success = true,
+                        path = generatedPath,
+                        message = "Image uploaded successfully."
+                    },
+                    errorMessage = (string)null
+                }));
+            }
+            catch (Exception ex)
+            {
+                return Ok(JObject.FromObject(new
+                {
+                    data = (object)null,
+                    errorMessage = "Cannot upload sample image.",
+                    errorDetails = ex.Message
+                }));
+            }
+        }
+
+        private static string ResolveSampleReportsDirectory()
+        {
+            try
+            {
+                string baseDir = AppDomain.CurrentDomain.BaseDirectory;
+
+                string frontendSampleDir = Path.GetFullPath(Path.Combine(baseDir, "..", "CEBReport-Frontend-main", "src", "assets", "SampleReports"));
+                string frontendAssetsDir = Path.GetFullPath(Path.Combine(baseDir, "..", "CEBReport-Frontend-main", "src", "assets"));
+
+                if (Directory.Exists(frontendAssetsDir) || Directory.Exists(frontendSampleDir))
+                {
+                    if (!Directory.Exists(frontendSampleDir))
+                    {
+                        Directory.CreateDirectory(frontendSampleDir);
+                    }
+                    return frontendSampleDir;
+                }
+
+                string appSampleDir = Path.GetFullPath(Path.Combine(baseDir, "src", "assets", "SampleReports"));
+                if (!Directory.Exists(appSampleDir))
+                {
+                    Directory.CreateDirectory(appSampleDir);
+                }
+                return appSampleDir;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error resolving sample reports directory: {ex.Message}");
+                string fallback = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "SampleReports");
+                if (!Directory.Exists(fallback))
+                {
+                    Directory.CreateDirectory(fallback);
+                }
+                return fallback;
             }
         }
     }

--- a/DAL/Admin/Report_Entry/ReportEntryRepository.cs
+++ b/DAL/Admin/Report_Entry/ReportEntryRepository.cs
@@ -62,22 +62,26 @@ namespace MISReports_Api.DAL
 
                         const string sql = @"
                             INSERT INTO REP_REPORTS_NEW
-                            (REPID_NO, REPID, CATCODE, REPNAME, PARAMLIST, FAVORITE, ACTIVE)
+                            (REPID_NO, REPID, CATCODE, REPNAME, PARAMLIST, FAVORITE, ACTIVE, DESCRIPTION, PATH)
                             VALUES
-                            (:repid_no, :repid, :catcode, :repname, :paramlist, :favorite, :active)";
+                            (:repid_no, :repid, :catcode, :repname, :paramlist, :favorite, :active, :description, :path)";
 
                         using (var cmd = new OracleCommand(sql, conn))
                         {
                             cmd.Transaction = transaction;
                             cmd.BindByName = true;
-                            cmd.Parameters.Add("repid_no",  OracleDbType.Int32).Value    = repIdNo;
-                            cmd.Parameters.Add("repid",     OracleDbType.Varchar2).Value  = NormalizeRepId(request.RepId);
-                            cmd.Parameters.Add("catcode",   OracleDbType.Varchar2).Value  = request.CatCode?.Trim();
-                            cmd.Parameters.Add("repname",   OracleDbType.Varchar2).Value  = request.RepName?.Trim();
-                            cmd.Parameters.Add("paramlist", OracleDbType.Varchar2).Value  =
+                            cmd.Parameters.Add("repid_no", OracleDbType.Int32).Value = repIdNo;
+                            cmd.Parameters.Add("repid", OracleDbType.Varchar2).Value = NormalizeRepId(request.RepId);
+                            cmd.Parameters.Add("catcode", OracleDbType.Varchar2).Value = request.CatCode?.Trim();
+                            cmd.Parameters.Add("repname", OracleDbType.Varchar2).Value = request.RepName?.Trim();
+                            cmd.Parameters.Add("paramlist", OracleDbType.Varchar2).Value =
                                 string.IsNullOrWhiteSpace(request.ParamList) ? (object)DBNull.Value : request.ParamList.Trim();
-                            cmd.Parameters.Add("favorite",  OracleDbType.Int32).Value    = favorite;
-                            cmd.Parameters.Add("active",    OracleDbType.Int32).Value    = active;
+                            cmd.Parameters.Add("favorite", OracleDbType.Int32).Value = favorite;
+                            cmd.Parameters.Add("active", OracleDbType.Int32).Value = active;
+                            cmd.Parameters.Add("description", OracleDbType.Varchar2).Value =
+                                string.IsNullOrWhiteSpace(request.Description) ? (object)DBNull.Value : request.Description.Trim();
+                            cmd.Parameters.Add("path", OracleDbType.Varchar2).Value =
+                                string.IsNullOrWhiteSpace(request.Path) ? (object)DBNull.Value : request.Path.Trim();
 
                             cmd.ExecuteNonQuery();
                         }
@@ -152,7 +156,9 @@ namespace MISReports_Api.DAL
                            REPNAME,
                            NVL(PARAMLIST, '') AS PARAMLIST,
                            FAVORITE,
-                           ACTIVE
+                           ACTIVE,
+                           DESCRIPTION,
+                           NVL(PATH, '') AS PATH
                     FROM REP_REPORTS_NEW
                     WHERE REPID_NO = :repid_no
                     AND CATCODE = :catcode";
@@ -178,7 +184,9 @@ namespace MISReports_Api.DAL
                             RepName = reader["REPNAME"]?.ToString()?.Trim(),
                             ParamList = reader["PARAMLIST"]?.ToString()?.Trim(),
                             Favorite = reader["FAVORITE"] != DBNull.Value ? Convert.ToInt32(reader["FAVORITE"]) : 0,
-                            Active = reader["ACTIVE"] != DBNull.Value ? Convert.ToInt32(reader["ACTIVE"]) : 0
+                            Active = reader["ACTIVE"] != DBNull.Value ? Convert.ToInt32(reader["ACTIVE"]) : 0,
+                            Description = reader["DESCRIPTION"]?.ToString()?.Trim(),
+                            Path = reader["PATH"]?.ToString()?.Trim()
                         };
                     }
                 }
@@ -339,11 +347,13 @@ namespace MISReports_Api.DAL
                         const string sql = @"
                             UPDATE REP_REPORTS_NEW
                             SET 
-                                CATCODE   = :catcode,
-                                REPNAME   = :repname,
-                                PARAMLIST = :paramlist,
-                                FAVORITE  = :favorite,
-                                ACTIVE    = :active
+                                CATCODE     = :catcode,
+                                REPNAME     = :repname,
+                                PARAMLIST   = :paramlist,
+                                FAVORITE    = :favorite,
+                                ACTIVE      = :active,
+                                DESCRIPTION = :description,
+                                PATH        = :path
                             WHERE 
                                 REPID_NO = :repid_no
                                 AND UPPER(TRIM(CATCODE)) = UPPER(TRIM(:current_catcode))";
@@ -352,14 +362,18 @@ namespace MISReports_Api.DAL
                         {
                             cmd.Transaction = transaction;
                             cmd.BindByName = true;
-                            cmd.Parameters.Add("catcode",        OracleDbType.Varchar2).Value = request.CatCode?.Trim();
-                            cmd.Parameters.Add("repname",        OracleDbType.Varchar2).Value = request.RepName?.Trim();
-                            cmd.Parameters.Add("paramlist",      OracleDbType.Varchar2).Value =
+                            cmd.Parameters.Add("catcode", OracleDbType.Varchar2).Value = request.CatCode?.Trim();
+                            cmd.Parameters.Add("repname", OracleDbType.Varchar2).Value = request.RepName?.Trim();
+                            cmd.Parameters.Add("paramlist", OracleDbType.Varchar2).Value =
                                 string.IsNullOrWhiteSpace(request.ParamList) ? (object)DBNull.Value : request.ParamList.Trim();
-                            cmd.Parameters.Add("favorite",       OracleDbType.Int32).Value    = favorite;
-                            cmd.Parameters.Add("active",         OracleDbType.Int32).Value    = active;
-                            cmd.Parameters.Add("repid_no",       OracleDbType.Int32).Value    = repIdNo;
-                            cmd.Parameters.Add("current_catcode",OracleDbType.Varchar2).Value = currentCatCode?.Trim();
+                            cmd.Parameters.Add("favorite", OracleDbType.Int32).Value = favorite;
+                            cmd.Parameters.Add("active", OracleDbType.Int32).Value = active;
+                            cmd.Parameters.Add("description", OracleDbType.Varchar2).Value =
+                                string.IsNullOrWhiteSpace(request.Description) ? (object)DBNull.Value : request.Description.Trim();
+                            cmd.Parameters.Add("path", OracleDbType.Varchar2).Value =
+                                string.IsNullOrWhiteSpace(request.Path) ? (object)DBNull.Value : request.Path.Trim();
+                            cmd.Parameters.Add("repid_no", OracleDbType.Int32).Value = repIdNo;
+                            cmd.Parameters.Add("current_catcode", OracleDbType.Varchar2).Value = currentCatCode?.Trim();
 
                             var affectedRows = cmd.ExecuteNonQuery();
                             if (affectedRows == 0)
@@ -383,24 +397,30 @@ namespace MISReports_Api.DAL
                                         const string fallbackSql = @"
                                             UPDATE REP_REPORTS_NEW
                                             SET 
-                                                CATCODE   = :catcode,
-                                                REPNAME   = :repname,
-                                                PARAMLIST = :paramlist,
-                                                FAVORITE  = :favorite,
-                                                ACTIVE    = :active
+                                                CATCODE     = :catcode,
+                                                REPNAME     = :repname,
+                                                PARAMLIST   = :paramlist,
+                                                FAVORITE    = :favorite,
+                                                ACTIVE      = :active,
+                                                DESCRIPTION = :description,
+                                                PATH        = :path
                                             WHERE REPID_NO = :repid_no";
 
                                         using (var fallbackCmd = new OracleCommand(fallbackSql, conn))
                                         {
                                             fallbackCmd.Transaction = transaction;
                                             fallbackCmd.BindByName = true;
-                                            fallbackCmd.Parameters.Add("catcode",   OracleDbType.Varchar2).Value = request.CatCode?.Trim();
-                                            fallbackCmd.Parameters.Add("repname",   OracleDbType.Varchar2).Value = request.RepName?.Trim();
+                                            fallbackCmd.Parameters.Add("catcode", OracleDbType.Varchar2).Value = request.CatCode?.Trim();
+                                            fallbackCmd.Parameters.Add("repname", OracleDbType.Varchar2).Value = request.RepName?.Trim();
                                             fallbackCmd.Parameters.Add("paramlist", OracleDbType.Varchar2).Value =
                                                 string.IsNullOrWhiteSpace(request.ParamList) ? (object)DBNull.Value : request.ParamList.Trim();
-                                            fallbackCmd.Parameters.Add("favorite",  OracleDbType.Int32).Value   = favorite;
-                                            fallbackCmd.Parameters.Add("active",    OracleDbType.Int32).Value   = active;
-                                            fallbackCmd.Parameters.Add("repid_no",  OracleDbType.Int32).Value   = repIdNo;
+                                            fallbackCmd.Parameters.Add("favorite", OracleDbType.Int32).Value = favorite;
+                                            fallbackCmd.Parameters.Add("active", OracleDbType.Int32).Value = active;
+                                            fallbackCmd.Parameters.Add("description", OracleDbType.Varchar2).Value =
+                                                string.IsNullOrWhiteSpace(request.Description) ? (object)DBNull.Value : request.Description.Trim();
+                                            fallbackCmd.Parameters.Add("path", OracleDbType.Varchar2).Value =
+                                                string.IsNullOrWhiteSpace(request.Path) ? (object)DBNull.Value : request.Path.Trim();
+                                            fallbackCmd.Parameters.Add("repid_no", OracleDbType.Int32).Value = repIdNo;
                                             affectedRows = fallbackCmd.ExecuteNonQuery();
                                         }
                                     }
@@ -517,7 +537,9 @@ namespace MISReports_Api.DAL
                                r.REPNAME,
                                NVL(r.PARAMLIST, '') AS PARAMLIST,
                                r.FAVORITE,
-                               r.ACTIVE
+                               r.ACTIVE,
+                               r.DESCRIPTION,
+                               NVL(r.PATH, '') AS PATH
                         FROM REP_REPORTS_NEW r
                         WHERE r.REPID = :repid
                         AND r.CATCODE = :catcode";
@@ -529,7 +551,9 @@ namespace MISReports_Api.DAL
                                r.REPNAME,
                                NVL(r1.PARAMLIST, '') AS PARAMLIST,
                                r.FAVORITE,
-                               r.ACTIVE
+                               r.ACTIVE,
+                               r.DESCRIPTION,
+                               NVL(r.PATH, '') AS PATH
                         FROM REP_REPORTS_NEW r
                         LEFT JOIN REP_REPORTS_NEW1 r1
                             ON UPPER(TRIM(r1.REPID)) = UPPER(TRIM(r.REPID))
@@ -556,7 +580,9 @@ namespace MISReports_Api.DAL
                                         RepName = reader["REPNAME"]?.ToString()?.Trim(),
                                         ParamList = reader["PARAMLIST"]?.ToString()?.Trim(),
                                         Favorite = reader["FAVORITE"] != DBNull.Value ? Convert.ToInt32(reader["FAVORITE"]) : 0,
-                                        Active = reader["ACTIVE"] != DBNull.Value ? Convert.ToInt32(reader["ACTIVE"]) : 0
+                                        Active = reader["ACTIVE"] != DBNull.Value ? Convert.ToInt32(reader["ACTIVE"]) : 0,
+                                        Description = reader["DESCRIPTION"]?.ToString()?.Trim(),
+                                        Path = reader["PATH"]?.ToString()?.Trim()
                                     });
                                 }
                             }
@@ -582,7 +608,9 @@ namespace MISReports_Api.DAL
                                         RepName = reader["REPNAME"]?.ToString()?.Trim(),
                                         ParamList = reader["PARAMLIST"]?.ToString()?.Trim(),
                                         Favorite = reader["FAVORITE"] != DBNull.Value ? Convert.ToInt32(reader["FAVORITE"]) : 0,
-                                        Active = reader["ACTIVE"] != DBNull.Value ? Convert.ToInt32(reader["ACTIVE"]) : 0
+                                        Active = reader["ACTIVE"] != DBNull.Value ? Convert.ToInt32(reader["ACTIVE"]) : 0,
+                                        Description = reader["DESCRIPTION"]?.ToString()?.Trim(),
+                                        Path = reader["PATH"]?.ToString()?.Trim()
                                     });
                                 }
                             }
@@ -616,7 +644,9 @@ namespace MISReports_Api.DAL
                                r.REPNAME,
                                NVL(r.PARAMLIST, '') AS PARAMLIST,
                                r.FAVORITE,
-                               r.ACTIVE
+                               r.ACTIVE,
+                               r.DESCRIPTION,
+                               NVL(r.PATH, '') AS PATH
                         FROM REP_REPORTS_NEW r
                         ORDER BY r.REPID_NO";
 
@@ -627,7 +657,9 @@ namespace MISReports_Api.DAL
                                r.REPNAME,
                                NVL(r1.PARAMLIST, '') AS PARAMLIST,
                                r.FAVORITE,
-                               r.ACTIVE
+                               r.ACTIVE,
+                               r.DESCRIPTION,
+                               NVL(r.PATH, '') AS PATH
                         FROM REP_REPORTS_NEW r
                         LEFT JOIN REP_REPORTS_NEW1 r1
                             ON UPPER(TRIM(r1.REPID)) = UPPER(TRIM(r.REPID))
@@ -649,7 +681,9 @@ namespace MISReports_Api.DAL
                                         RepName = reader["REPNAME"]?.ToString()?.Trim(),
                                         ParamList = reader["PARAMLIST"]?.ToString()?.Trim(),
                                         Favorite = reader["FAVORITE"] != DBNull.Value ? Convert.ToInt32(reader["FAVORITE"]) : 0,
-                                        Active = reader["ACTIVE"] != DBNull.Value ? Convert.ToInt32(reader["ACTIVE"]) : 0
+                                        Active = reader["ACTIVE"] != DBNull.Value ? Convert.ToInt32(reader["ACTIVE"]) : 0,
+                                        Description = reader["DESCRIPTION"]?.ToString()?.Trim(),
+                                        Path = reader["PATH"]?.ToString()?.Trim()
                                     });
                                 }
                             }
@@ -671,7 +705,9 @@ namespace MISReports_Api.DAL
                                         RepName = reader["REPNAME"]?.ToString()?.Trim(),
                                         ParamList = reader["PARAMLIST"]?.ToString()?.Trim(),
                                         Favorite = reader["FAVORITE"] != DBNull.Value ? Convert.ToInt32(reader["FAVORITE"]) : 0,
-                                        Active = reader["ACTIVE"] != DBNull.Value ? Convert.ToInt32(reader["ACTIVE"]) : 0
+                                        Active = reader["ACTIVE"] != DBNull.Value ? Convert.ToInt32(reader["ACTIVE"]) : 0,
+                                        Description = reader["DESCRIPTION"]?.ToString()?.Trim(),
+                                        Path = reader["PATH"]?.ToString()?.Trim()
                                     });
                                 }
                             }
@@ -705,7 +741,9 @@ namespace MISReports_Api.DAL
                                r.REPNAME,
                                NVL(r.PARAMLIST, '') AS PARAMLIST,
                                r.FAVORITE,
-                               r.ACTIVE
+                               r.ACTIVE,
+                               r.DESCRIPTION,
+                               NVL(r.PATH, '') AS PATH
                         FROM REP_REPORTS_NEW r
                         WHERE UPPER(TRIM(r.CATCODE)) = UPPER(TRIM(:catcode))
                         ORDER BY r.REPNAME";
@@ -727,7 +765,9 @@ namespace MISReports_Api.DAL
                                     RepName = reader["REPNAME"]?.ToString()?.Trim(),
                                     ParamList = reader["PARAMLIST"]?.ToString()?.Trim(),
                                     Favorite = reader["FAVORITE"] != DBNull.Value ? Convert.ToInt32(reader["FAVORITE"]) : 0,
-                                    Active = reader["ACTIVE"] != DBNull.Value ? Convert.ToInt32(reader["ACTIVE"]) : 0
+                                    Active = reader["ACTIVE"] != DBNull.Value ? Convert.ToInt32(reader["ACTIVE"]) : 0,
+                                    Description = reader["DESCRIPTION"]?.ToString()?.Trim(),
+                                    Path = reader["PATH"]?.ToString()?.Trim()
                                 });
                             }
                         }

--- a/Models/Admin/Report_Entry/ReportEntryModel.cs
+++ b/Models/Admin/Report_Entry/ReportEntryModel.cs
@@ -11,6 +11,8 @@ namespace MISReports_Api.Models
         public string ParamList { get; set; }
         public int Favorite { get; set; }
         public int Active { get; set; }
+        public string Description { get; set; }
+        public string Path { get; set; }
     }
 }
 


### PR DESCRIPTION
Add POST /upload endpoint in ReportEntryController to accept multipart/form-data image uploads (PNG/JPG/JPEG). Uploaded images are normalized to {repId}.{ext}, stored under frontend or app assets (deleting previous variants), and return a generated asset path. Includes ResolveSampleReportsDirectory helper and basic validation/error handling.

Update ReportEntryRepository to persist DESCRIPTION and PATH: add columns to INSERT/UPDATE queries, bind parameters, and include fields in SELECTs; map DB values to the model. Add Description and Path properties to ReportEntryModel.