### PR TITLE
Expose ProvinceCode field on Solar Customer Information (Ordinary + Bulk)

### DIFF
--- a/DAL/SolarInformation/SolarCustomerInformation/SolarCustomerInforBulkDao.cs
+++ b/DAL/SolarInformation/SolarCustomerInformation/SolarCustomerInforBulkDao.cs
@@ -176,7 +176,7 @@ namespace MISReports_Api.DAO.SolarInformation.SolarCustomerInformation
                     {
                         System.Diagnostics.Trace.WriteLine($"=== Attempting to fetch area info for AreaCode: '{customerInfo.AreaCode}' ===");
 
-                        string areaQuery = @"SELECT a.area_name, p.prov_name, a.region 
+                        string areaQuery = @"SELECT a.area_name, p.prov_name, p.prov_code, a.region 
                             FROM areas a, provinces p 
                             WHERE a.prov_code = p.prov_code 
                             AND a.area_code = ?";
@@ -190,6 +190,7 @@ namespace MISReports_Api.DAO.SolarInformation.SolarCustomerInformation
                                 if (reader.Read())
                                 {
                                     customerInfo.AreaName = reader["area_name"]?.ToString()?.Trim() ?? "";
+                                    customerInfo.ProvinceCode = reader["prov_code"]?.ToString()?.Trim() ?? "";
                                     customerInfo.ProvinceName = reader["prov_name"]?.ToString()?.Trim() ?? "";
                                     customerInfo.Region = reader["region"]?.ToString()?.Trim() ?? "";
 
@@ -199,6 +200,7 @@ namespace MISReports_Api.DAO.SolarInformation.SolarCustomerInformation
                                 {
                                     System.Diagnostics.Trace.WriteLine($"No area information found for area_cd: '{customerInfo.AreaCode}'");
                                     customerInfo.AreaName = customerInfo.AreaCode; // Fallback to area code
+                                    customerInfo.ProvinceCode = "";
                                     customerInfo.ProvinceName = " ";
                                     customerInfo.Region = " ";
                                 }

--- a/DAL/SolarInformation/SolarCustomerInformation/SolarCustomerInforOrdinaryDao.cs
+++ b/DAL/SolarInformation/SolarCustomerInformation/SolarCustomerInforOrdinaryDao.cs
@@ -66,6 +66,7 @@ namespace MISReports_Api.DAO.SolarInformation.SolarCustomerInformation
                     if (areaInfo != null)
                     {
                         response.CustomerInfo.AreaName = areaInfo.AreaName;
+                        response.CustomerInfo.ProvinceCode = areaInfo.ProvinceCode;
                         response.CustomerInfo.ProvinceName = areaInfo.ProvinceName;
                         response.CustomerInfo.Region = areaInfo.Region;
                     }
@@ -303,7 +304,7 @@ namespace MISReports_Api.DAO.SolarInformation.SolarCustomerInformation
                 {
                     conn.Open();
 
-                    string query = @"SELECT a.area_name, p.prov_name, a.region 
+                    string query = @"SELECT a.area_name, p.prov_name, p.prov_code, a.region 
                                    FROM areas a, provinces p 
                                    WHERE a.prov_code = p.prov_code 
                                    AND a.area_code = ?";
@@ -319,6 +320,7 @@ namespace MISReports_Api.DAO.SolarInformation.SolarCustomerInformation
                                 areaInfo = new AreaInformation
                                 {
                                     AreaName = reader["area_name"]?.ToString()?.Trim() ?? "",
+                                    ProvinceCode = reader["prov_code"]?.ToString()?.Trim() ?? "",
                                     ProvinceName = reader["prov_name"]?.ToString()?.Trim() ?? "",
                                     Region = reader["region"]?.ToString()?.Trim() ?? ""
                                 };
@@ -477,6 +479,7 @@ namespace MISReports_Api.DAO.SolarInformation.SolarCustomerInformation
         private class AreaInformation
         {
             public string AreaName { get; set; }
+            public string ProvinceCode { get; set; }
             public string ProvinceName { get; set; }
             public string Region { get; set; }
         }

--- a/Models/SolarInformation/SolarCustomerInforModel.cs
+++ b/Models/SolarInformation/SolarCustomerInforModel.cs
@@ -46,6 +46,7 @@ namespace MISReports_Api.Models.SolarInformation
         public string MeterNumber3 { get; set; }
         public string AreaCode { get; set; }
         public string AreaName { get; set; }
+        public string ProvinceCode { get; set; }
         public string ProvinceName { get; set; }
         public string Region { get; set; }
         public string TariffCode { get; set; }


### PR DESCRIPTION
## What this does

Adds a `ProvinceCode` field to the Solar Customer Information response, alongside the existing `AreaCode`, `AreaName`, `ProvinceName`, and `Region` fields. No new database calls — both DAOs already join `areas` with `provinces` on `prov_code` to resolve the province name and region, so this just adds `p.prov_code` to that existing `SELECT` and passes it through.

## Why

The frontend's account-lookup screen (Solar Customer Information) needs to compare a queried account's province against the logged-in user's own province to determine whether they're allowed to view that account's details (part of the level-based access control work). 
`ProvinceName` alone isn't reliable for this comparison since the user's stored province value is a code, not a display name. 
This PR only exposes the code — no access logic lives here; that enforcement happens entirely on the frontend, consistent with how the rest of this feature has been implemented.

## Files changed

- `Models/SolarInformation/SolarCustomerInforModel.cs` — added `ProvinceCode` to `SolarCustomerBasicInfo`
- `DAL/SolarInformation/SolarCustomerInformation/SolarCustomerInforOrdinaryDao.cs` — added `ProvinceCode` to the internal `AreaInformation` helper and its query/mapping
- `DAL/SolarInformation/SolarCustomerInformation/SolarCustomerInforBulkDao.cs` — same addition to its equivalent area-info lookup