### PR TITLE
Add MaterialFlow API, DAL and model

### DIFF
--- a/Controllers/Inventory/MaterialFlowController.cs
+++ b/Controllers/Inventory/MaterialFlowController.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using MISReports_Api.DAL;
+using MISReports_Api.Models.Accounts;
+namespace MISReports_Api.Controllers
+{
+    [RoutePrefix("api/materialflow")]
+    public class MaterialFlowController : ApiController
+    {
+        private readonly MaterialFlowDAL _dal = new MaterialFlowDAL();
+
+        // PATH: /api/materialflow/report/2026-05-09/2026-07-09/510.00/EBG120007G/A/WH_CEPP
+        [HttpGet]
+        [Route("report/{fromDate}/{toDate}/{costCtr}/{matCode}/{grCode}/{whCode}")]
+        public IHttpActionResult GetReport(string fromDate, string toDate, string costCtr, string matCode, string grCode, string whCode)
+        {
+            return ExecuteQuery(fromDate, toDate, costCtr, matCode, grCode, whCode);
+        }
+
+        // QUERY: /api/materialflow/report?fromDate=2026-05-09&toDate=2026-07-09&costCtr=510.00&matCode=EBG120007G&grCode=A&whCode=WH_CEPP
+        [HttpGet]
+        [Route("report")]
+        public IHttpActionResult GetQuery(
+            [FromUri] string fromDate, [FromUri] string toDate, [FromUri] string costCtr,
+            [FromUri] string matCode, [FromUri] string grCode, [FromUri] string whCode)
+        {
+            return ExecuteQuery(fromDate, toDate, costCtr, matCode, grCode, whCode);
+        }
+
+        // GET: /api/materialflow/gradecodes
+        [HttpGet]
+        [Route("gradecodes")]
+        public IHttpActionResult GetGradeCodes()
+        {
+            try
+            {
+                var codes = _dal.GetDistinctGradeCodes();
+                return Ok(new { success = true, data = codes });
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error: {ex.Message}\n{ex.StackTrace}");
+                return InternalServerError(new Exception($"Database error: {ex.Message}", ex));
+            }
+        }
+
+        private IHttpActionResult ExecuteQuery(string fromDate, string toDate, string costCtr, string matCode, string grCode, string whCode)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(fromDate) || !DateTime.TryParse(fromDate, out DateTime fromDt))
+                    return BadRequest("fromDate must be a valid date (e.g., 2026-05-09).");
+                if (string.IsNullOrWhiteSpace(toDate) || !DateTime.TryParse(toDate, out DateTime toDt))
+                    return BadRequest("toDate must be a valid date (e.g., 2026-07-09).");
+                if (toDt < fromDt)
+                    return BadRequest("toDate cannot be earlier than fromDate.");
+                if (string.IsNullOrWhiteSpace(costCtr))
+                    return BadRequest("costCtr is required.");
+                if (string.IsNullOrWhiteSpace(matCode))
+                    return BadRequest("matCode is required.");
+                if (string.IsNullOrWhiteSpace(grCode))
+                    return BadRequest("grCode is required.");
+                if (string.IsNullOrWhiteSpace(whCode))
+                    return BadRequest("whCode is required.");
+
+                // SQL uses TO_DATE(:param,'yyyy/mm/dd'), so format to match the mask.
+                string fromDateFormatted = fromDt.ToString("yyyy/MM/dd");
+                string toDateFormatted = toDt.ToString("yyyy/MM/dd");
+
+                var data = _dal.GetMaterialFlow(
+                    fromDateFormatted, toDateFormatted, costCtr.Trim(),
+                    matCode.Trim(), grCode.Trim(), whCode.Trim());
+
+                // QtyOnHandP / QIn / QOut / CIn / COut are scalar values (same on every
+                // row) computed by the SQL's correlated subqueries, so take them from the
+                // first row if present.
+                decimal qtyOnHand = data.FirstOrDefault()?.QtyOnHandP ?? 0m;
+                decimal qIn = data.FirstOrDefault()?.QIn ?? 0m;
+                decimal qOut = data.FirstOrDefault()?.QOut ?? 0m;
+                decimal cIn = data.FirstOrDefault()?.CIn ?? 0m;
+                decimal cOut = data.FirstOrDefault()?.COut ?? 0m;
+
+                decimal openingQty = qtyOnHand + qIn + qOut;
+                decimal closingQty = qtyOnHand + cIn + cOut;
+
+                const int MAX_RECORDS = 5000;
+                var summary = new
+                {
+                    fromDate = fromDt.ToString("yyyy-MM-dd"),
+                    toDate = toDt.ToString("yyyy-MM-dd"),
+                    costCtr = costCtr.Trim(),
+                    matCode = matCode.Trim(),
+                    grCode = grCode.Trim(),
+                    whCode = whCode.Trim(),
+                    totalRecords = data.Count,
+                    qtyOnHand,
+                    openingQty,
+                    closingQty
+                };
+
+                if (data.Count >= MAX_RECORDS)
+                {
+                    return Ok(new
+                    {
+                        success = false,
+                        message = $"Too many records ({data.Count}). Result capped at {MAX_RECORDS}. Use narrower filters.",
+                        data = new object[0],
+                        summary
+                    });
+                }
+
+                return Ok(new
+                {
+                    success = true,
+                    message = data.Any() ? "Data retrieved successfully" : "No records found",
+                    data,
+                    summary
+                });
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error: {ex.Message}\n{ex.StackTrace}");
+                return InternalServerError(new Exception($"Database error: {ex.Message}", ex));
+            }
+        }
+    }
+}

--- a/DAL/Inventory/MaterialFlowDAL.cs
+++ b/DAL/Inventory/MaterialFlowDAL.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Configuration;
+using System.Data;
+using Oracle.ManagedDataAccess.Client;
+using MISReports_Api.Models.Accounts;
+namespace MISReports_Api.DAL
+{
+    public class MaterialFlowDAL
+    {
+        private readonly string _connectionString =
+            ConfigurationManager.ConnectionStrings["HQOracle"].ConnectionString;
+
+        public List<MaterialFlowModel> GetMaterialFlow(string fromDate, string toDate, string costCtr, string matCode, string grCode, string whCode)
+        {
+            var result = new List<MaterialFlowModel>();
+            const string query = @"
+                SELECT T1.doc_no,
+                       T1.trx_type,
+                       CASE WHEN T2.is_ref IS NOT NULL THEN T2.is_ref ELSE T2.rc_ref END AS iss_ref,
+                       SUM(CASE WHEN T1.add_deduct = 'T' THEN T1.trx_qty
+                                WHEN T1.add_deduct = 'F' THEN -T1.trx_qty
+                                ELSE NULL END) AS add_or_sub,
+                       T1.trx_dt AS tr_date,
+                       T2.ref_3, T2.ref_4,
+                       (CASE WHEN T1.add_deduct = 'T' THEN 1 ELSE 0 END) AS addition,
+                       (SELECT dept_nm FROM gldeptm WHERE TRIM(dept_id) = TRIM(:costctr)) AS CCT_NAME,
+                       (SELECT SUM(qty_on_hand)
+                          FROM inwrhmtm
+                         WHERE TRIM(wrh_cd) = TRIM(:whcode)
+                           AND TRIM(dept_id) = TRIM(:costctr)
+                           AND TRIM(grade_cd) = TRIM(:grcode)
+                           AND TRIM(mat_cd) = TRIM(:matcode)) AS qty_on_handp,
+                       (SELECT SUM(CASE WHEN (T1.add_deduct = 'T') THEN (-T1.trx_qty) ELSE 0 END)
+                          FROM inpostmt T1
+                         WHERE TRIM(T1.dept_id) = TRIM(:costctr)
+                           AND TRIM(T1.mat_cd) = TRIM(:matcode)
+                           AND TRIM(T1.grade_cd) = TRIM(:grcode)
+                           AND T1.trx_dt >= TO_DATE(:fromdate,'yyyy/mm/dd')
+                           AND TRIM(T1.wrh_cd) = TRIM(:whcode)
+                           AND NOT (T1.trx_type IN ('PRICE_ADJ'))) AS q_in,
+                       (SELECT SUM(CASE WHEN (T1.add_deduct = 'F') THEN (T1.trx_qty) ELSE 0 END)
+                          FROM inpostmt T1
+                         WHERE TRIM(T1.dept_id) = TRIM(:costctr)
+                           AND TRIM(T1.mat_cd) = TRIM(:matcode)
+                           AND TRIM(T1.grade_cd) = TRIM(:grcode)
+                           AND T1.trx_dt >= TO_DATE(:fromdate,'yyyy/mm/dd')
+                           AND TRIM(T1.wrh_cd) = TRIM(:whcode)
+                           AND NOT (T1.trx_type IN ('PRICE_ADJ'))) AS q_out,
+                       (SELECT SUM(CASE WHEN (T1.add_deduct = 'T') THEN (-T1.trx_qty) ELSE 0 END)
+                          FROM inpostmt T1
+                         WHERE TRIM(T1.dept_id) = TRIM(:costctr)
+                           AND TRIM(T1.mat_cd) = TRIM(:matcode)
+                           AND TRIM(T1.grade_cd) = TRIM(:grcode)
+                           AND T1.trx_dt > TO_DATE(:todate,'yyyy/mm/dd')
+                           AND TRIM(T1.wrh_cd) = TRIM(:whcode)
+                           AND NOT (T1.trx_type IN ('PRICE_ADJ'))) AS cin,
+                       (SELECT SUM(CASE WHEN (T1.add_deduct = 'F') THEN (T1.trx_qty) ELSE 0 END)
+                          FROM inpostmt T1
+                         WHERE TRIM(T1.dept_id) = TRIM(:costctr)
+                           AND TRIM(T1.mat_cd) = TRIM(:matcode)
+                           AND TRIM(T1.grade_cd) = TRIM(:grcode)
+                           AND T1.trx_dt > TO_DATE(:todate,'yyyy/mm/dd')
+                           AND TRIM(T1.wrh_cd) = TRIM(:whcode)
+                           AND NOT (T1.trx_type IN ('PRICE_ADJ'))) AS cout
+                FROM (inpostmt T1 LEFT OUTER JOIN intrhmt T2
+                        ON T1.doc_no = T2.doc_no
+                       AND T1.doc_pf = T2.doc_pf
+                       AND T1.dept_id = T2.dept_id
+                       AND TRIM(T1.dept_id) = TRIM(:costctr))
+                WHERE TRIM(T1.dept_id) = TRIM(:costctr)
+                  AND TRIM(T1.mat_cd) = TRIM(:matcode)
+                  AND TRIM(T1.grade_cd) = TRIM(:grcode)
+                  AND TRIM(T1.wrh_cd) = TRIM(:whcode)
+                  AND NOT (T1.trx_type IN ('PRICE_ADJ'))
+                  AND T1.trx_dt >= TO_DATE(:fromdate,'yyyy/mm/dd')
+                  AND T1.trx_dt <= TO_DATE(:todate,'yyyy/mm/dd')
+                GROUP BY T1.doc_no, T1.trx_type, T1.trx_dt, T1.add_deduct,
+                         CASE WHEN T2.is_ref IS NOT NULL THEN T2.is_ref ELSE T2.rc_ref END,
+                         T2.ref_3, T2.ref_4
+                ORDER BY 5 ASC, 1 ASC, 2 ASC";
+
+            using (var conn = new OracleConnection(_connectionString))
+            using (var cmd = new OracleCommand(query, conn))
+            {
+                cmd.CommandType = CommandType.Text;
+                cmd.BindByName = true; // required so repeated named params bind correctly
+                cmd.Parameters.Add(new OracleParameter("costctr", OracleDbType.Varchar2) { Value = costCtr });
+                cmd.Parameters.Add(new OracleParameter("matcode", OracleDbType.Varchar2) { Value = matCode });
+                cmd.Parameters.Add(new OracleParameter("grcode", OracleDbType.Varchar2) { Value = grCode });
+                cmd.Parameters.Add(new OracleParameter("whcode", OracleDbType.Varchar2) { Value = whCode });
+                cmd.Parameters.Add(new OracleParameter("fromdate", OracleDbType.Varchar2) { Value = fromDate });
+                cmd.Parameters.Add(new OracleParameter("todate", OracleDbType.Varchar2) { Value = toDate });
+
+                conn.Open();
+                using (var reader = cmd.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        result.Add(new MaterialFlowModel
+                        {
+                            DocNo = reader["doc_no"] == DBNull.Value ? null : reader["doc_no"].ToString(),
+                            TrxType = reader["trx_type"] == DBNull.Value ? null : reader["trx_type"].ToString(),
+                            IssRef = reader["iss_ref"] == DBNull.Value ? null : reader["iss_ref"].ToString(),
+                            AddOrSub = reader["add_or_sub"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["add_or_sub"]),
+                            TrxDate = reader["tr_date"] == DBNull.Value ? (DateTime?)null : Convert.ToDateTime(reader["tr_date"]),
+                            Ref3 = reader["ref_3"] == DBNull.Value ? null : reader["ref_3"].ToString(),
+                            Ref4 = reader["ref_4"] == DBNull.Value ? null : reader["ref_4"].ToString(),
+                            Addition = reader["addition"] == DBNull.Value ? (int?)null : Convert.ToInt32(reader["addition"]),
+                            CctName = reader["CCT_NAME"] == DBNull.Value ? null : reader["CCT_NAME"].ToString(),
+                            QtyOnHandP = reader["qty_on_handp"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["qty_on_handp"]),
+                            QIn = reader["q_in"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["q_in"]),
+                            QOut = reader["q_out"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["q_out"]),
+                            CIn = reader["cin"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["cin"]),
+                            COut = reader["cout"] == DBNull.Value ? (decimal?)null : Convert.ToDecimal(reader["cout"])
+                        });
+                    }
+                }
+            }
+            return result;
+        }
+
+        public List<string> GetDistinctGradeCodes()
+        {
+            var result = new List<string>();
+            const string query = "SELECT DISTINCT(grade_cd) FROM inwrhmtm ORDER BY grade_cd";
+
+            using (var conn = new OracleConnection(_connectionString))
+            using (var cmd = new OracleCommand(query, conn))
+            {
+                cmd.CommandType = CommandType.Text;
+                conn.Open();
+                using (var reader = cmd.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        if (reader["grade_cd"] != DBNull.Value)
+                            result.Add(reader["grade_cd"].ToString());
+                    }
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/Models/Inventory/MaterialFlowModel.cs
+++ b/Models/Inventory/MaterialFlowModel.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+namespace MISReports_Api.Models.Accounts
+{
+    public class MaterialFlowModel
+    {
+        public string DocNo { get; set; }
+        public string TrxType { get; set; }
+        public string IssRef { get; set; }
+        public decimal? AddOrSub { get; set; }
+        public DateTime? TrxDate { get; set; }
+        public string Ref3 { get; set; }
+        public string Ref4 { get; set; }
+        public int? Addition { get; set; }
+        public string CctName { get; set; }
+        public decimal? QtyOnHandP { get; set; }
+        public decimal? QIn { get; set; }
+        public decimal? QOut { get; set; }
+        public decimal? CIn { get; set; }
+        public decimal? COut { get; set; }
+    }
+}


### PR DESCRIPTION
Introduce MaterialFlow feature: adds MaterialFlowController (API endpoints for /api/materialflow/report and /api/materialflow/gradecodes), MaterialFlowDAL (Oracle queries using Oracle.ManagedDataAccess to fetch material flow rows and distinct grade codes using HQOracle connection string), and MaterialFlowModel (POCO for result mapping). Controller validates inputs, formats dates, computes opening/closing quantities from DAL-provided scalars, and caps large results (5000). Includes error handling and diagnostic logging.